### PR TITLE
fix: Update AI model references from GPT-4 to o3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ class TestEmojiGenerator:
 
 **Repository Pattern Benefits:**
 - **Testability** - Mock `SlackRepository` and `OpenAIRepository` in unit tests without real API calls
-- **Flexibility** - Easy to swap between OpenAI models (GPT-4, DALL-E) without changing business logic  
+- **Flexibility** - Easy to swap between OpenAI models (o3, DALL-E) without changing business logic  
 - **Clean boundaries** - Domain logic doesn't know about HTTP clients, API specifics, or external service details
 
 **Dependency Injection Benefits:**
@@ -253,7 +253,7 @@ class OpenAIRepository(ABC):
     
     @abstractmethod 
     async def enhance_prompt(self, context: str, description: str) -> str:
-        """Use GPT-4 to enhance emoji generation prompt."""
+        """Use o3 to enhance emoji generation prompt."""
         pass
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ graph LR
 
 **Tech Stack:**
 - **Backend**: Python 3.12 + FastAPI + Slack Bolt
-- **AI Services**: OpenAI GPT-4 (prompt enhancement) + DALL-E (image generation)
+- **AI Services**: OpenAI o3 (prompt enhancement) + DALL-E (image generation)
 - **Infrastructure**: AWS Lambda + API Gateway + Secrets Manager
 - **Deployment**: AWS CDK + GitHub Actions
 - **Security**: Bandit SAST scanning + least-privilege IAM


### PR DESCRIPTION
## Summary

Quick fix to update all documentation references from GPT-4 to o3 as requested.

### Changes Made
- **README.md**: Updated tech stack to show "OpenAI o3 (prompt enhancement) + DALL-E"
- **CLAUDE.md**: Updated repository pattern examples and documentation comments

### Context
This addresses the feedback on the merged PR #54 to use o3 instead of GPT-4 for prompt enhancement, ensuring consistency with the updated Issue #51.

### Test Plan
- [x] Documentation reads correctly
- [x] All references to GPT-4 replaced with o3
- [x] Technical accuracy maintained

## Type of Change
- [x] Bug fix (documentation correction)
- [x] Non-breaking change

🤖 Generated with [Claude Code](https://claude.ai/code)