### PR TITLE
refactor: move SlackRepository protocol to domain layer following DDD…

### DIFF
--- a/src/emojismith/application/handlers/slack_webhook.py
+++ b/src/emojismith/application/handlers/slack_webhook.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, Any, Protocol
 from emojismith.domain.entities.slack_message import SlackMessage
+from emojismith.domain.repositories import SlackRepository
 
 
 class EmojiService(Protocol):
@@ -11,14 +12,6 @@ class EmojiService(Protocol):
         self, message: SlackMessage, trigger_id: str
     ) -> None:
         """Initiate emoji creation process."""
-        ...
-
-
-class SlackRepository(Protocol):
-    """Protocol for Slack API operations."""
-
-    async def open_modal(self, trigger_id: str, view: Dict[str, Any]) -> None:
-        """Open modal dialog in Slack."""
         ...
 
 

--- a/src/emojismith/domain/repositories/__init__.py
+++ b/src/emojismith/domain/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Domain repositories."""
+
+from .slack_repository import SlackRepository
+
+__all__ = ["SlackRepository"]

--- a/src/emojismith/domain/repositories/slack_repository.py
+++ b/src/emojismith/domain/repositories/slack_repository.py
@@ -1,0 +1,11 @@
+"""Slack repository protocol for domain layer."""
+
+from typing import Dict, Any, Protocol
+
+
+class SlackRepository(Protocol):
+    """Protocol for Slack API operations."""
+
+    async def open_modal(self, trigger_id: str, view: Dict[str, Any]) -> None:
+        """Open modal dialog in Slack."""
+        ...


### PR DESCRIPTION
… principles

- Move SlackRepository protocol from application/handlers to domain/repositories
- Update imports in SlackWebhookHandler to use domain layer protocol
- Improve separation of concerns following clean architecture patterns

🤖 Generated with [Claude Code](https://claude.ai/code)