### PR TITLE
Fix DALL‑E image size handling

### DIFF
--- a/src/emojismith/infrastructure/image/processing.py
+++ b/src/emojismith/infrastructure/image/processing.py
@@ -20,11 +20,10 @@ class PillowImageProcessor:
         with Image.open(BytesIO(image_data)) as img:
             img = img.convert("RGBA")
             img = img.resize((128, 128))
+            img = img.quantize(colors=256)
             output = BytesIO()
             img.save(output, format="PNG", optimize=True)
             data = output.getvalue()
             if len(data) >= 64 * 1024:
-                output = BytesIO()
-                img.save(output, format="PNG", optimize=True)
-                data = output.getvalue()
+                raise ValueError("processed image too large")
             return data

--- a/tests/unit/infrastructure/image/test_processing.py
+++ b/tests/unit/infrastructure/image/test_processing.py
@@ -5,7 +5,7 @@ from PIL import Image
 from emojismith.infrastructure.image.processing import PillowImageProcessor
 
 
-def _create_image(size=(256, 256)) -> bytes:
+def _create_image(size=(1024, 1024)) -> bytes:
     img = Image.new("RGBA", size, "green")
     bio = BytesIO()
     img.save(bio, format="PNG")

--- a/tests/unit/infrastructure/openai/test_openai_api.py
+++ b/tests/unit/infrastructure/openai/test_openai_api.py
@@ -26,4 +26,15 @@ async def test_generate_image_calls_client() -> None:
     repo = OpenAIAPIRepository(client)
     data = await repo.generate_image("prompt")
     assert isinstance(data, bytes)
-    client.images.generate.assert_called_once()
+    client.images.generate.assert_called_once_with(
+        model="dall-e-3", prompt="prompt", n=1, size="1024x1024"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_image_raises_on_missing_data() -> None:
+    client = AsyncMock()
+    client.images.generate.return_value = AsyncMock(data=[])
+    repo = OpenAIAPIRepository(client)
+    with pytest.raises(ValueError):
+        await repo.generate_image("p")


### PR DESCRIPTION
## Summary
- request DALL-E 3 images at 1024x1024
- resize and quantize images in `PillowImageProcessor`
- improve error handling and tests

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_684d50e99bb0832998e970a864eabd6b