### PR TITLE
Remove SQS details from domain entities

### DIFF
--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -49,7 +49,7 @@ def create_webhook_handler() -> SlackWebhookHandler:
 def _create_sqs_job_queue() -> JobQueueRepository:
     """Create SQS job queue for Lambda environment."""
     try:
-        import aioboto3  # type: ignore[import-untyped]
+        import aioboto3  # type: ignore[import-not-found]
         from emojismith.infrastructure.jobs.sqs_job_queue import SQSJobQueue
 
         session = aioboto3.Session()

--- a/src/emojismith/domain/entities/emoji_generation_job.py
+++ b/src/emojismith/domain/entities/emoji_generation_job.py
@@ -1,10 +1,10 @@
 """EmojiGenerationJob domain entity."""
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 
 class JobStatus(Enum):
@@ -29,7 +29,6 @@ class EmojiGenerationJob:
     team_id: str
     status: JobStatus
     created_at: datetime
-    _receipt_handle: Optional[str] = field(default=None, init=False)
 
     @classmethod
     def create_new(

--- a/src/emojismith/domain/repositories/job_queue_repository.py
+++ b/src/emojismith/domain/repositories/job_queue_repository.py
@@ -1,6 +1,6 @@
 """Job queue repository protocol for domain layer."""
 
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Dict, Optional, Protocol, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 
 
@@ -11,12 +11,16 @@ class JobQueueRepository(Protocol):
         """Enqueue a new emoji generation job."""
         ...
 
-    async def dequeue_job(self) -> Optional[EmojiGenerationJob]:
-        """Dequeue the next pending job for processing."""
+    async def dequeue_job(self) -> Optional[Tuple[EmojiGenerationJob, str]]:
+        """Dequeue the next pending job for processing.
+
+        Returns a tuple of the job and an implementation-specific receipt
+        handle used to acknowledge completion.
+        """
         ...
 
-    async def complete_job(self, job: EmojiGenerationJob) -> None:
-        """Mark job as completed and remove from queue."""
+    async def complete_job(self, job: EmojiGenerationJob, receipt_handle: str) -> None:
+        """Mark job as completed and remove from queue using the receipt handle."""
         ...
 
     async def get_job_status(self, job_id: str) -> Optional[str]:

--- a/src/emojismith/infrastructure/jobs/background_worker.py
+++ b/src/emojismith/infrastructure/jobs/background_worker.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
 from emojismith.application.services.emoji_service import EmojiCreationService
 
@@ -46,11 +46,12 @@ class BackgroundWorker:
         while self._running:
             try:
                 # Get next job from queue
-                job = await self._job_queue.dequeue_job()
+                job_tuple = await self._job_queue.dequeue_job()
 
-                if job:
+                if job_tuple:
+                    job, receipt_handle = job_tuple
                     # Process job concurrently within semaphore limits
-                    asyncio.create_task(self._process_single_job(job))
+                    asyncio.create_task(self._process_single_job(job, receipt_handle))
                 else:
                     # No jobs available, wait before polling again
                     await asyncio.sleep(self._poll_interval)
@@ -61,7 +62,9 @@ class BackgroundWorker:
                 )
                 await asyncio.sleep(self._poll_interval)
 
-    async def _process_single_job(self, job: Any) -> None:
+    async def _process_single_job(
+        self, job: EmojiGenerationJob, receipt_handle: str
+    ) -> None:
         """Process a single emoji generation job."""
         async with self._semaphore:
             self._logger.info(
@@ -77,7 +80,7 @@ class BackgroundWorker:
                 await self._emoji_service.process_emoji_generation_job(job)
 
                 # Mark job as completed
-                await self._job_queue.complete_job(job)
+                await self._job_queue.complete_job(job, receipt_handle)
                 await self._job_queue.update_job_status(job.job_id, "completed")
 
                 self._logger.info(

--- a/src/emojismith/infrastructure/jobs/sqs_job_queue.py
+++ b/src/emojismith/infrastructure/jobs/sqs_job_queue.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
 
@@ -48,8 +48,11 @@ class SQSJobQueue(JobQueueRepository):
 
         return job.job_id
 
-    async def dequeue_job(self) -> Optional[EmojiGenerationJob]:
-        """Dequeue the next pending job for processing."""
+    async def dequeue_job(self) -> Optional[Tuple[EmojiGenerationJob, str]]:
+        """Dequeue the next pending job for processing.
+
+        Returns a tuple of the job and the SQS receipt handle.
+        """
         response = await self._sqs_client.receive_message(
             QueueUrl=self._queue_url,
             MaxNumberOfMessages=1,
@@ -67,16 +70,14 @@ class SQSJobQueue(JobQueueRepository):
             # Parse job data from message body
             job_data = json.loads(message["Body"])
             job = EmojiGenerationJob.from_dict(job_data)
-
-            # Store receipt handle for deletion after processing
-            job._receipt_handle = message["ReceiptHandle"]
+            receipt_handle = message["ReceiptHandle"]
 
             self._logger.info(
                 "Dequeued emoji generation job",
                 extra={"job_id": job.job_id, "user_id": job.user_id},
             )
 
-            return job
+            return job, receipt_handle
 
         except (json.JSONDecodeError, KeyError) as e:
             self._logger.error(
@@ -87,13 +88,12 @@ class SQSJobQueue(JobQueueRepository):
             await self._delete_message(message["ReceiptHandle"])
             return None
 
-    async def complete_job(self, job: EmojiGenerationJob) -> None:
+    async def complete_job(self, job: EmojiGenerationJob, receipt_handle: str) -> None:
         """Mark job as completed and remove from queue."""
-        if hasattr(job, "_receipt_handle"):
-            await self._delete_message(job._receipt_handle)
-            self._logger.info(
-                "Completed and removed job from queue", extra={"job_id": job.job_id}
-            )
+        await self._delete_message(receipt_handle)
+        self._logger.info(
+            "Completed and removed job from queue", extra={"job_id": job.job_id}
+        )
 
     async def _delete_message(self, receipt_handle: Optional[str]) -> None:
         """Delete message from SQS queue if a receipt handle is present."""

--- a/tests/unit/domain/repositories/test_image_processor.py
+++ b/tests/unit/domain/repositories/test_image_processor.py
@@ -7,12 +7,12 @@ def test_image_processor_protocol_defines_process_method() -> None:
     """Test that ImageProcessor protocol defines the required process method."""
     # This test ensures the protocol is defined correctly
     assert hasattr(ImageProcessor, "process")
-    
+
     # Check that we can implement the protocol
     class TestProcessor(ImageProcessor):
         def process(self, image_data: bytes) -> bytes:
             return image_data
-    
+
     processor = TestProcessor()
     result = processor.process(b"test data")
     assert result == b"test data"

--- a/tests/unit/infrastructure/jobs/test_background_worker.py
+++ b/tests/unit/infrastructure/jobs/test_background_worker.py
@@ -21,7 +21,7 @@ class DummyJobQueue:
     async def update_job_status(self, job_id, status):
         pass
 
-    async def complete_job(self, job):
+    async def complete_job(self, job, receipt_handle):
         pass
 
 


### PR DESCRIPTION
## Summary
- decouple EmojiGenerationJob from SQS receipt handles
- change JobQueueRepository API to pass receipt handle separately
- update SQSJobQueue and BackgroundWorker for new API
- adjust tests for the new interface

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_684e1eb4ca38832981e23211d51b151f