### PR TITLE
Remove receipt handle from domain entity

### DIFF
--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -49,7 +49,7 @@ def create_webhook_handler() -> SlackWebhookHandler:
 def _create_sqs_job_queue() -> JobQueueRepository:
     """Create SQS job queue for Lambda environment."""
     try:
-        import aioboto3  # type: ignore[import-untyped]
+        import aioboto3  # type: ignore[import-not-found]
         from emojismith.infrastructure.jobs.sqs_job_queue import SQSJobQueue
 
         session = aioboto3.Session()

--- a/src/emojismith/domain/entities/emoji_generation_job.py
+++ b/src/emojismith/domain/entities/emoji_generation_job.py
@@ -1,10 +1,10 @@
 """EmojiGenerationJob domain entity."""
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 
 class JobStatus(Enum):
@@ -29,7 +29,6 @@ class EmojiGenerationJob:
     team_id: str
     status: JobStatus
     created_at: datetime
-    _receipt_handle: Optional[str] = field(default=None, init=False)
 
     @classmethod
     def create_new(

--- a/src/emojismith/domain/repositories/job_queue_repository.py
+++ b/src/emojismith/domain/repositories/job_queue_repository.py
@@ -1,6 +1,6 @@
 """Job queue repository protocol for domain layer."""
 
-from typing import Dict, Any, Optional, Protocol
+from typing import Dict, Any, Optional, Protocol, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 
 
@@ -11,12 +11,12 @@ class JobQueueRepository(Protocol):
         """Enqueue a new emoji generation job."""
         ...
 
-    async def dequeue_job(self) -> Optional[EmojiGenerationJob]:
-        """Dequeue the next pending job for processing."""
+    async def dequeue_job(self) -> Optional[Tuple[EmojiGenerationJob, str]]:
+        """Dequeue the next pending job for processing and return the job with its receipt handle."""
         ...
 
-    async def complete_job(self, job: EmojiGenerationJob) -> None:
-        """Mark job as completed and remove from queue."""
+    async def complete_job(self, job: EmojiGenerationJob, receipt_handle: str) -> None:
+        """Mark job as completed and remove from queue using the receipt handle."""
         ...
 
     async def get_job_status(self, job_id: str) -> Optional[str]:

--- a/src/emojismith/infrastructure/jobs/sqs_job_queue.py
+++ b/src/emojismith/infrastructure/jobs/sqs_job_queue.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
 
@@ -48,8 +48,8 @@ class SQSJobQueue(JobQueueRepository):
 
         return job.job_id
 
-    async def dequeue_job(self) -> Optional[EmojiGenerationJob]:
-        """Dequeue the next pending job for processing."""
+    async def dequeue_job(self) -> Optional[Tuple[EmojiGenerationJob, str]]:
+        """Dequeue the next pending job and return it with its receipt handle."""
         response = await self._sqs_client.receive_message(
             QueueUrl=self._queue_url,
             MaxNumberOfMessages=1,
@@ -67,16 +67,14 @@ class SQSJobQueue(JobQueueRepository):
             # Parse job data from message body
             job_data = json.loads(message["Body"])
             job = EmojiGenerationJob.from_dict(job_data)
-
-            # Store receipt handle for deletion after processing
-            job._receipt_handle = message["ReceiptHandle"]
+            receipt_handle = message["ReceiptHandle"]
 
             self._logger.info(
                 "Dequeued emoji generation job",
                 extra={"job_id": job.job_id, "user_id": job.user_id},
             )
 
-            return job
+            return job, receipt_handle
 
         except (json.JSONDecodeError, KeyError) as e:
             self._logger.error(
@@ -87,13 +85,12 @@ class SQSJobQueue(JobQueueRepository):
             await self._delete_message(message["ReceiptHandle"])
             return None
 
-    async def complete_job(self, job: EmojiGenerationJob) -> None:
+    async def complete_job(self, job: EmojiGenerationJob, receipt_handle: str) -> None:
         """Mark job as completed and remove from queue."""
-        if hasattr(job, "_receipt_handle"):
-            await self._delete_message(job._receipt_handle)
-            self._logger.info(
-                "Completed and removed job from queue", extra={"job_id": job.job_id}
-            )
+        await self._delete_message(receipt_handle)
+        self._logger.info(
+            "Completed and removed job from queue", extra={"job_id": job.job_id}
+        )
 
     async def _delete_message(self, receipt_handle: Optional[str]) -> None:
         """Delete message from SQS queue if a receipt handle is present."""

--- a/tests/unit/infrastructure/jobs/test_background_worker.py
+++ b/tests/unit/infrastructure/jobs/test_background_worker.py
@@ -21,7 +21,7 @@ class DummyJobQueue:
     async def update_job_status(self, job_id, status):
         pass
 
-    async def complete_job(self, job):
+    async def complete_job(self, job, receipt_handle):
         pass
 
 

--- a/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
+++ b/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
@@ -75,12 +75,14 @@ class TestSQSJobQueue:
         }
 
         # Act
-        job = await sqs_queue.dequeue_job()
+        result = await sqs_queue.dequeue_job()
 
         # Assert
         mock_sqs_client.receive_message.assert_called_once()
-        assert job is not None
+        assert result is not None
+        job, receipt_handle = result
         assert job.job_id == "job_123"
+        assert receipt_handle == "receipt_123"
 
     async def test_complete_job_deletes_message(self, sqs_queue, mock_sqs_client):
         """Test complete_job calls delete_message when receipt_handle is present."""
@@ -95,10 +97,8 @@ class TestSQSJobQueue:
             timestamp="ts",
             team_id="T1",
         )
-        job._receipt_handle = "rh"
-
         # Act
-        await sqs_queue.complete_job(job)
+        await sqs_queue.complete_job(job, "rh")
 
         # Assert
         mock_sqs_client.delete_message.assert_called_once_with(
@@ -124,8 +124,8 @@ class TestSQSJobQueue:
         malformed = {"Messages": [{"ReceiptHandle": "rh", "Body": "not a json"}]}
         mock_sqs_client.receive_message.return_value = malformed
 
-        job = await sqs_queue.dequeue_job()
-        assert job is None
+        result = await sqs_queue.dequeue_job()
+        assert result is None
         mock_sqs_client.delete_message.assert_called_once_with(
             QueueUrl=sqs_queue._queue_url, ReceiptHandle="rh"
         )


### PR DESCRIPTION
## Summary
- refactor `EmojiGenerationJob` to remove SQS receipt handle
- update `JobQueueRepository` interface to return receipt handle separately
- adjust `SQSJobQueue` and `BackgroundWorker` for new API
- fix mypy ignore for aioboto3
- update unit tests for queue changes

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_684e1eb4ca38832981e23211d51b151f