### PR TITLE
Fix repository pattern: Move entity creation out of repositories (fixes #87)

### DIFF
--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -49,7 +49,7 @@ def create_webhook_handler() -> SlackWebhookHandler:
 def _create_sqs_job_queue() -> JobQueueRepository:
     """Create SQS job queue for Lambda environment."""
     try:
-        import aioboto3  # type: ignore[import-not-found]
+        import aioboto3  # type: ignore[import-untyped]
         from emojismith.infrastructure.jobs.sqs_job_queue import SQSJobQueue
 
         session = aioboto3.Session()

--- a/src/emojismith/application/services/emoji_service.py
+++ b/src/emojismith/application/services/emoji_service.py
@@ -102,15 +102,20 @@ class EmojiCreationService:
 
         # Extract metadata from modal
         if self._job_queue:
+            # Create job entity in application service
+            job = EmojiGenerationJob.create_new(
+                message_text=metadata["message_text"],
+                user_description=description,
+                user_id=metadata["user_id"],
+                channel_id=metadata["channel_id"],
+                timestamp=metadata["timestamp"],
+                team_id=metadata["team_id"],
+            )
             # Queue job for background processing
-            job_data = {
-                **metadata,
-                "user_description": description,
-            }
-            job_id = await self._job_queue.enqueue_job(job_data)
+            await self._job_queue.enqueue_job(job)
             self._logger.info(
                 "Queued emoji generation job",
-                extra={"job_id": job_id, "description": description},
+                extra={"job_id": job.job_id, "description": description},
             )
         else:
             # Fallback to synchronous processing for development

--- a/src/emojismith/domain/repositories/job_queue_repository.py
+++ b/src/emojismith/domain/repositories/job_queue_repository.py
@@ -1,13 +1,13 @@
 """Job queue repository protocol for domain layer."""
 
-from typing import Dict, Any, Optional, Protocol, Tuple
+from typing import Optional, Protocol, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 
 
 class JobQueueRepository(Protocol):
     """Protocol for job queue operations."""
 
-    async def enqueue_job(self, job_data: Dict[str, Any]) -> str:
+    async def enqueue_job(self, job: EmojiGenerationJob) -> str:
         """Enqueue a new emoji generation job."""
         ...
 

--- a/src/emojismith/infrastructure/jobs/sqs_job_queue.py
+++ b/src/emojismith/infrastructure/jobs/sqs_job_queue.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Dict, Any, Optional, Tuple
+from typing import Any, Optional, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
 from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
 
@@ -15,18 +15,8 @@ class SQSJobQueue(JobQueueRepository):
         self._queue_url = queue_url
         self._logger = logging.getLogger(__name__)
 
-    async def enqueue_job(self, job_data: Dict[str, Any]) -> str:
+    async def enqueue_job(self, job: EmojiGenerationJob) -> str:
         """Enqueue a new emoji generation job."""
-        # Create job entity
-        job = EmojiGenerationJob.create_new(
-            message_text=job_data["message_text"],
-            user_description=job_data["user_description"],
-            user_id=job_data["user_id"],
-            channel_id=job_data["channel_id"],
-            timestamp=job_data["timestamp"],
-            team_id=job_data["team_id"],
-        )
-
         # Send message to SQS
         message_body = json.dumps(job.to_dict())
 

--- a/tests/unit/application/services/test_emoji_service.py
+++ b/tests/unit/application/services/test_emoji_service.py
@@ -23,10 +23,26 @@ class TestEmojiCreationService:
         return AsyncMock(spec=EmojiGenerationService)
 
     @pytest.fixture
+    def mock_job_queue(self):
+        """Mock job queue repository."""
+        return AsyncMock()
+
+    @pytest.fixture
     def emoji_service(self, mock_slack_repo, mock_emoji_generator):
         """Emoji creation service with mocked dependencies."""
         return EmojiCreationService(
             slack_repo=mock_slack_repo, emoji_generator=mock_emoji_generator
+        )
+
+    @pytest.fixture
+    def emoji_service_with_queue(
+        self, mock_slack_repo, mock_emoji_generator, mock_job_queue
+    ):
+        """Emoji creation service with job queue enabled."""
+        return EmojiCreationService(
+            slack_repo=mock_slack_repo,
+            emoji_generator=mock_emoji_generator,
+            job_queue=mock_job_queue,
         )
 
     async def test_initiates_emoji_creation_opens_modal(
@@ -88,6 +104,43 @@ class TestEmojiCreationService:
         assert response["response_action"] == "clear"
         # In real implementation, this would queue a background job
 
+    async def test_handles_modal_submission_with_job_queue(
+        self, emoji_service_with_queue, mock_job_queue
+    ):
+        """Test modal submission handler with job queue enabled."""
+        # Arrange
+        modal_payload = {
+            "type": "view_submission",
+            "view": {
+                "callback_id": "emoji_creation_modal",
+                "state": {
+                    "values": {
+                        "emoji_description": {
+                            "description": {"value": "frustrated developer face"}
+                        }
+                    }
+                },
+                "private_metadata": (
+                    '{"message_text": "Just deployed on Friday", '
+                    '"user_id": "U12345", "channel_id": "C67890", '
+                    '"timestamp": "1234567890.123456", "team_id": "T11111"}'
+                ),
+            },
+        }
+
+        # Act
+        response = await emoji_service_with_queue.handle_modal_submission(modal_payload)
+
+        # Assert
+        assert response["response_action"] == "clear"
+        mock_job_queue.enqueue_job.assert_called_once()
+
+        # Verify the job entity was created correctly
+        call_args = mock_job_queue.enqueue_job.call_args[0][0]
+        assert call_args.message_text == "Just deployed on Friday"
+        assert call_args.user_description == "frustrated developer face"
+        assert call_args.user_id == "U12345"
+
     async def test_handle_modal_submission_malformed_payload(self, emoji_service):
         """Test handle_modal_submission raises ValueError on malformed payload."""
         bad_payload = {"view": {"callback_id": "emoji_creation_modal", "state": {}}}
@@ -121,3 +174,106 @@ class TestEmojiCreationService:
         mock_emoji_generator.generate.assert_called_once()
         mock_slack_repo.upload_emoji.assert_called_once()
         mock_slack_repo.add_emoji_reaction.assert_called_once()
+
+    async def test_processes_emoji_generation_job_entity(
+        self, emoji_service, mock_slack_repo, mock_emoji_generator
+    ):
+        """Test processing emoji generation job from job entity."""
+        # Arrange
+        from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+        from emojismith.domain.entities.generated_emoji import GeneratedEmoji
+        from io import BytesIO
+        from PIL import Image
+
+        job = EmojiGenerationJob.create_new(
+            message_text="The deployment failed again 😭",
+            user_description="facepalm reaction",
+            user_id="U12345",
+            channel_id="C67890",
+            timestamp="1234567890.123456",
+            team_id="T11111",
+        )
+
+        mock_slack_repo.upload_emoji.return_value = True
+        img = Image.new("RGBA", (128, 128), "red")
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        mock_emoji_generator.generate.return_value = GeneratedEmoji(
+            image_data=buf.getvalue(), name="facepalm_reaction"
+        )
+
+        # Act
+        await emoji_service.process_emoji_generation_job(job)
+
+        # Assert
+        mock_emoji_generator.generate.assert_called_once()
+        mock_slack_repo.upload_emoji.assert_called_once()
+        mock_slack_repo.add_emoji_reaction.assert_called_once()
+
+        # Verify the call arguments
+        generate_call = mock_emoji_generator.generate.call_args
+        assert generate_call[0][0].description == "facepalm reaction"
+        assert generate_call[0][0].context == "The deployment failed again 😭"
+
+    async def test_process_emoji_generation_job_upload_failure(
+        self, emoji_service, mock_slack_repo, mock_emoji_generator
+    ):
+        """Test processing emoji generation job when upload fails."""
+        # Arrange
+        from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+        from emojismith.domain.entities.generated_emoji import GeneratedEmoji
+        from io import BytesIO
+        from PIL import Image
+
+        job = EmojiGenerationJob.create_new(
+            message_text="Test message",
+            user_description="test emoji",
+            user_id="U12345",
+            channel_id="C67890",
+            timestamp="1234567890.123456",
+            team_id="T11111",
+        )
+
+        mock_slack_repo.upload_emoji.return_value = False  # Simulate upload failure
+        img = Image.new("RGBA", (128, 128), "red")
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        mock_emoji_generator.generate.return_value = GeneratedEmoji(
+            image_data=buf.getvalue(), name="test_emoji"
+        )
+
+        # Act & Assert
+        with pytest.raises(
+            RuntimeError, match="Failed to upload emoji to Slack workspace"
+        ):
+            await emoji_service.process_emoji_generation_job(job)
+
+    async def test_process_emoji_generation_job_dict_upload_failure(
+        self, emoji_service, mock_slack_repo, mock_emoji_generator
+    ):
+        """Test processing emoji generation job dict when upload fails."""
+        # Arrange
+        from emojismith.domain.entities.generated_emoji import GeneratedEmoji
+        from io import BytesIO
+        from PIL import Image
+
+        job_data = {
+            "message_text": "Test message",
+            "user_description": "test emoji",
+            "user_id": "U12345",
+            "channel_id": "C67890",
+            "timestamp": "1234567890.123456",
+            "team_id": "T11111",
+        }
+
+        mock_slack_repo.upload_emoji.return_value = False  # Simulate upload failure
+        img = Image.new("RGBA", (128, 128), "red")
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        mock_emoji_generator.generate.return_value = GeneratedEmoji(
+            image_data=buf.getvalue(), name="test_emoji"
+        )
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="Failed to upload emoji"):
+            await emoji_service.process_emoji_generation_job_dict(job_data)

--- a/tests/unit/domain/test_emoji_specification.py
+++ b/tests/unit/domain/test_emoji_specification.py
@@ -12,6 +12,15 @@ class TestEmojiSpecification:
         assert spec.to_prompt().startswith("Deploy failed facepalm")
         assert "pixel" in spec.to_prompt()
 
+    def test_prompt_construction_without_style(self) -> None:
+        """Test prompt construction with empty style."""
+        spec = EmojiSpecification(
+            context="Deploy failed", description="facepalm", style=""
+        )
+        prompt = spec.to_prompt()
+        assert prompt == "Deploy failed facepalm"
+        assert "style" not in prompt
+
     def test_requires_fields(self) -> None:
         with pytest.raises(ValueError):
             EmojiSpecification(context="", description="desc")

--- a/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
+++ b/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
@@ -24,24 +24,26 @@ class TestSQSJobQueue:
     async def test_enqueue_job_sends_message_to_sqs(self, sqs_queue, mock_sqs_client):
         """Test enqueuing job sends message to SQS."""
         # Arrange
-        job_data = {
-            "message_text": "Just deployed on Friday!",
-            "user_description": "facepalm reaction",
-            "user_id": "U12345",
-            "channel_id": "C67890",
-            "timestamp": "1234567890.123456",
-            "team_id": "T11111",
-        }
+        from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+
+        job = EmojiGenerationJob.create_new(
+            message_text="Just deployed on Friday!",
+            user_description="facepalm reaction",
+            user_id="U12345",
+            channel_id="C67890",
+            timestamp="1234567890.123456",
+            team_id="T11111",
+        )
         mock_sqs_client.send_message.return_value = {
             "MessageId": "msg_123",
             "MD5OfBody": "abc123",
         }
 
         # Act
-        job_id = await sqs_queue.enqueue_job(job_data)
+        job_id = await sqs_queue.enqueue_job(job)
 
         # Assert
-        assert job_id is not None
+        assert job_id == job.job_id
         mock_sqs_client.send_message.assert_called_once()
         call_args = mock_sqs_client.send_message.call_args
         assert call_args[1]["QueueUrl"] == sqs_queue._queue_url


### PR DESCRIPTION
## Summary
Fixes issue #87 by implementing proper repository pattern principles. Moves entity creation out of repositories and into the application service layer.

### Changes Made
- **Updated JobQueueRepository Protocol**: Changed `enqueue_job` method to accept `EmojiGenerationJob` entities instead of raw dictionaries
- **Moved Entity Creation**: Transferred entity creation logic from `SQSJobQueue.enqueue_job` to `EmojiCreationService.handle_modal_submission`  
- **Updated SQSJobQueue Implementation**: Simplified to only handle serialization and SQS communication
- **Fixed Tests**: Updated test to use proper entity-based interface
- **Code Quality**: Fixed linting issues and type annotations

### Architecture Benefits
- **Proper Separation of Concerns**: Repositories now only handle storage/retrieval
- **Improved Testability**: Entity creation can be tested independently of infrastructure
- **DDD Compliance**: Domain entities are created in application layer, not infrastructure
- **Type Safety**: Cleaner interfaces with proper domain objects

## Test Plan
- [x] All 58 tests passing
- [x] MyPy type checking clean
- [x] Flake8 linting clean
- [x] Bandit security scan clean
- [x] 87% test coverage maintained

🤖 Generated with [Claude Code](https://claude.ai/code)