### PR TITLE
fix: resolve GitHub Actions deployment pipeline issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: testing
-    if: github.event_name == 'push'  # Run on all branches
+    # Run on feature branches (PRs) and main branch (push)
     outputs:
       image-uri: ${{ steps.build-image.outputs.image }}
     steps:
@@ -147,7 +147,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+        aws-region: us-east-2
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
@@ -158,7 +158,7 @@ jobs:
     - name: Install Node.js for CDK
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: Install AWS CDK
       run: npm install -g aws-cdk

--- a/infra/stacks/emoji_smith_stack.py
+++ b/infra/stacks/emoji_smith_stack.py
@@ -116,6 +116,25 @@ class EmojiSmithStack(Stack):
                         f"arn:aws:iam::{self.account}:role/EmojiSmithStack-*"
                     ],
                 ),
+                # CDK bootstrap permissions
+                iam.PolicyStatement(
+                    actions=[
+                        "ssm:GetParameter",
+                        "ssm:GetParameters",
+                    ],
+                    resources=[
+                        f"arn:aws:ssm:{self.region}:{self.account}:parameter/cdk-bootstrap/*"
+                    ],
+                ),
+                # STS permissions for CDK role assumption
+                iam.PolicyStatement(
+                    actions=[
+                        "sts:AssumeRole",
+                    ],
+                    resources=[
+                        f"arn:aws:iam::{self.account}:role/cdk-*"
+                    ],
+                ),
                 # Read-only permissions to check existing resources
                 iam.PolicyStatement(
                     actions=[


### PR DESCRIPTION
## Summary
Fixes multiple critical deployment pipeline issues preventing successful GitHub Actions deployments.

## Issues Resolved

### 🔐 **CDK Bootstrap Permissions**
**Problem**: Deployment user couldn't access CDK bootstrap parameters
```
AccessDeniedException: User: arn:aws:iam::714944708230:user/emoji-smith-deployment-user 
is not authorized to perform: ssm:GetParameter on resource: 
arn:aws:ssm:us-east-1:714944708230:parameter/cdk-bootstrap/hnb659fds/version
```

**Solution**: Added proper SSM and STS permissions
- `ssm:GetParameter` on `/cdk-bootstrap/*` parameters
- `sts:AssumeRole` on `cdk-*` roles for proper CDK operation

### 🌍 **AWS Region Mismatch**
**Problem**: Deploy stage still using `us-east-1` while infrastructure is in `us-east-2`

**Solution**: Corrected AWS region in deploy stage to `us-east-2`

### 🟢 **Node.js End-of-Life Warning**
**Problem**: Using Node.js 18 which reached end-of-life on 2025-04-30
```
Node 18 has reached end-of-life on 2025-04-30 and is not supported.
```

**Solution**: Upgraded to Node.js 20 (supported until 2026-04-30)

### 🚀 **Feature Branch Build Support**
**Problem**: Build stage wouldn't run on feature branches, preventing proper testing

**Solution**: Removed restrictive `if: github.event_name == 'push'` condition
- Build stage now runs on both PRs and pushes
- Deploy stage remains restricted to main branch only

## Security Validation

### ✅ **Least Privilege IAM Permissions**
- **SSM access**: Scoped to `/cdk-bootstrap/*` parameters only
- **STS access**: Limited to `cdk-*` roles for CDK operations
- **No wildcard permissions** added unnecessarily

### ✅ **Deployment Security**
- Deploy stage still restricted to main branch only
- Build stage allows testing on feature branches safely
- No production secrets exposed

## Testing Results

- ✅ CDK deployment successful with new permissions
- ✅ IAM policy update applied without issues
- ✅ Ready for GitHub Actions pipeline testing

## Changes Made

### `infra/stacks/emoji_smith_stack.py`
- Added SSM permissions for CDK bootstrap parameter access
- Added STS permissions for CDK role assumption
- Maintains least privilege with proper resource scoping

### `.github/workflows/deploy.yml`
- Fixed AWS region mismatch (`us-east-1` → `us-east-2`)
- Upgraded Node.js from 18 to 20
- Enabled build stage on feature branches
- Deploy stage remains main-branch only

## Expected Outcome
GitHub Actions deployments should now succeed without permission errors or region mismatches.

🤖 Generated with [Claude Code](https://claude.ai/code)