### PR TITLE
fix: add missing /slack/interactive endpoint for Slack message actions

### DIFF
--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -168,4 +168,11 @@ def create_app() -> FastAPI:
             return await webhook_handler.handle_modal_submission(payload)
         return {"status": "ignored"}
 
+    @app.post("/slack/interactive")
+    async def slack_interactive(request: Request) -> Dict[str, Any]:
+        """Handle Slack interactive components (modals, buttons, etc.)."""
+        # Use the same logic as slack_events since interactive components
+        # are just a subset of Slack webhook events
+        return await slack_events(request)
+
     return app


### PR DESCRIPTION
## Summary
Fixes the issue where clicking "emoji-smith" in Slack message actions does nothing by adding the missing `/slack/interactive` endpoint.

## Problem
When users right-click on a message and select "emoji-smith" from the "More actions" menu, nothing happens. CloudWatch logs show the Lambda function receives requests but they're very short (1-2ms) with no application logs.

## Root Cause
The API Gateway routes `/slack/interactive` requests to the Lambda function, but the FastAPI app only has a `/slack/events` endpoint. Interactive components (message actions, modals, buttons) require a separate endpoint from event subscriptions.

## Solution
Added `/slack/interactive` endpoint that routes to the same handler logic as `/slack/events` since interactive components are processed the same way as other Slack webhook events.

### Code Changes
```python
@app.post("/slack/interactive")
async def slack_interactive(request: Request) -> Dict[str, Any]:
    """Handle Slack interactive components (modals, buttons, etc.)."""
    # Use the same logic as slack_events since interactive components
    # are just a subset of Slack webhook events
    return await slack_events(request)
```

## Validation
- ✅ Both `/slack/events` and `/slack/interactive` now route to the same handler
- ✅ Message actions will trigger the `message_action` event type processing
- ✅ Modal submissions will trigger the `view_submission` event type processing

## Expected Behavior After Fix
1. User right-clicks on a message in Slack
2. Selects "emoji-smith" from "More actions" menu  
3. Modal dialog opens for emoji creation
4. User can specify emoji description and generate custom emoji

## Testing
After deployment, test by:
1. Right-clicking any message in Slack
2. Selecting "emoji-smith" 
3. Confirming modal dialog appears

🤖 Generated with [Claude Code](https://claude.ai/code)