### PR TITLE
fix: use async context manager for aioboto3 SQS client

### DIFF
--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -88,7 +88,6 @@ def _create_sqs_job_queue() -> JobQueueRepository:
         from emojismith.infrastructure.jobs.sqs_job_queue import SQSJobQueue
 
         session = aioboto3.Session()
-        sqs_client = session.client("sqs")
         queue_url = os.getenv("SQS_QUEUE_URL")
 
         if not queue_url:
@@ -96,7 +95,7 @@ def _create_sqs_job_queue() -> JobQueueRepository:
                 "SQS_QUEUE_URL environment variable is required for Lambda"
             )
 
-        return SQSJobQueue(sqs_client=sqs_client, queue_url=queue_url)
+        return SQSJobQueue(session=session, queue_url=queue_url)
     except ImportError:
         raise RuntimeError(
             "aioboto3 is required for SQS job queue in Lambda environment"


### PR DESCRIPTION
- Change SQSJobQueue to accept aioboto3 session instead of client
- Use 'async with session.client("sqs")' pattern for all SQS operations
- Update tests to properly mock async context manager
- Resolves AttributeError: 'ClientCreatorContext' object has no attribute 'send_message'

🤖 Generated with [Claude Code](https://claude.ai/code)