### PR TITLE
Fix SQS FIFO parameters for standard queue

### DIFF
--- a/src/emojismith/infrastructure/jobs/sqs_job_queue.py
+++ b/src/emojismith/infrastructure/jobs/sqs_job_queue.py
@@ -29,8 +29,6 @@ class SQSJobQueue(JobQueueRepository):
             response = await sqs_client.send_message(
                 QueueUrl=self._queue_url,
                 MessageBody=message_body,
-                MessageGroupId="emoji-generation",  # For FIFO queues
-                MessageDeduplicationId=job.job_id,  # For FIFO queues
             )
 
         self._logger.info(

--- a/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
+++ b/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
@@ -61,6 +61,9 @@ class TestSQSJobQueue:
         call_args = mock_sqs_client.send_message.call_args
         assert call_args.kwargs["QueueUrl"] == sqs_queue.queue_url
         assert "MessageBody" in call_args.kwargs
+        # Verify FIFO parameters are not sent for standard queue
+        assert "MessageGroupId" not in call_args.kwargs
+        assert "MessageDeduplicationId" not in call_args.kwargs
 
     async def test_retrieves_next_emoji_job_for_processing(
         self, sqs_queue, mock_sqs_client


### PR DESCRIPTION
## Summary
- Remove FIFO-specific parameters from standard SQS queue operations
- Fix `MessageDeduplicationId is invalid for this queue type` error in CloudWatch logs
- Add test assertions to verify FIFO parameters are excluded

## Changes
- **SQS Queue Fix**: Removed `MessageGroupId` and `MessageDeduplicationId` from `send_message()` calls
- **Test Enhancement**: Added assertions to verify FIFO parameters are not included in SQS calls
- **Error Resolution**: Eliminates CloudWatch errors preventing proper job queue functionality

## Testing
- ✅ All existing tests pass
- ✅ New test assertions verify FIFO parameters are excluded
- ✅ 87% test coverage maintained
- ✅ Code quality checks pass (black, flake8, mypy, bandit)

## GitHub Issue
Resolves #127

🤖 Generated with [Claude Code](https://claude.ai/code)