### PR TITLE
Optimize Dockerfile per issue 128

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+*.md
+tests
+infra
+run_dev.sh
+requirements-dev.lock
+uv.lock
+*.pyc
+__pycache__/
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-# Use the official AWS Lambda Python runtime
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.12 AS builder
+WORKDIR /app
 
-# Copy source code first for editable install
+# Install production dependencies
+COPY requirements.lock .
+RUN pip install --no-cache-dir --target /app -r requirements.lock
+
+FROM public.ecr.aws/lambda/python:3.12-slim
+# Copy dependencies from builder image
+COPY --from=builder /app /var/runtime
+
+# Copy application source
 COPY src/ ${LAMBDA_TASK_ROOT}/
-COPY src/lambda_handler.py ${LAMBDA_TASK_ROOT}/
-COPY src/worker_handler.py ${LAMBDA_TASK_ROOT}/
-COPY pyproject.toml ${LAMBDA_TASK_ROOT}/
 
-# Copy requirements and install dependencies (excluding editable install)
-COPY requirements.lock ${LAMBDA_TASK_ROOT}/
-RUN grep -v "^-e \." requirements.lock > requirements-no-editable.lock && \
-    pip install --no-cache-dir -r requirements-no-editable.lock
-
-# Set the CMD to your handler (could also be worker_handler.handler for worker Lambda)
+# Default Lambda handler
 CMD ["lambda_handler.handler"]


### PR DESCRIPTION
## Summary
- implement multi-stage build for leaner Docker image
- add `.dockerignore` to exclude tests and dev files

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src --cov-fail-under=80 tests/`

------
https://chatgpt.com/codex/tasks/task_e_68501a44499c8329aa68b2cdc5a42e7c