### PR TITLE
Fix trigger_id expiration with async modal opening

### DIFF
--- a/src/emojismith/application/services/emoji_service.py
+++ b/src/emojismith/application/services/emoji_service.py
@@ -419,6 +419,19 @@ class EmojiCreationService:
         # In production, this could check API permissions or be configured
         return WorkspaceType.STANDARD
 
+    async def queue_modal_opening(
+        self, slack_message: SlackMessage, trigger_id: str
+    ) -> None:
+        """Queue modal opening for asynchronous processing."""
+        if not self._job_queue:
+            raise ValueError("Job queue not configured for async modal opening")
+
+        await self._job_queue.enqueue_modal_opening(slack_message, trigger_id)
+        self._logger.info(
+            "Queued modal opening for async processing",
+            extra={"trigger_id": trigger_id, "user_id": slack_message.user_id},
+        )
+
     async def process_emoji_generation_job_dict(self, job_data: Dict[str, Any]) -> None:
         """Generate emoji using dict payload, upload to Slack, and add reaction."""
         # Convert dict to job entity for consistent processing

--- a/src/emojismith/domain/entities/queue_message.py
+++ b/src/emojismith/domain/entities/queue_message.py
@@ -1,0 +1,105 @@
+"""Queue message entities for different operation types."""
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, Any, Union
+
+from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+from emojismith.domain.entities.slack_message import SlackMessage
+
+
+class MessageType(Enum):
+    """Types of messages that can be queued."""
+
+    EMOJI_GENERATION = "emoji_generation"
+    MODAL_OPENING = "modal_opening"
+
+
+@dataclass
+class ModalOpeningMessage:
+    """Message for opening Slack modal asynchronously."""
+
+    message_id: str
+    slack_message: SlackMessage
+    trigger_id: str
+    created_at: datetime
+
+    @classmethod
+    def create_new(
+        cls,
+        slack_message: SlackMessage,
+        trigger_id: str,
+    ) -> "ModalOpeningMessage":
+        """Create a new modal opening message."""
+        return cls(
+            message_id=str(uuid.uuid4()),
+            slack_message=slack_message,
+            trigger_id=trigger_id,
+            created_at=datetime.now(timezone.utc),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "message_id": self.message_id,
+            "slack_message": {
+                "text": self.slack_message.text,
+                "user_id": self.slack_message.user_id,
+                "channel_id": self.slack_message.channel_id,
+                "timestamp": self.slack_message.timestamp,
+                "team_id": self.slack_message.team_id,
+            },
+            "trigger_id": self.trigger_id,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ModalOpeningMessage":
+        """Create from dictionary."""
+        slack_msg_data = data["slack_message"]
+        slack_message = SlackMessage(
+            text=slack_msg_data["text"],
+            user_id=slack_msg_data["user_id"],
+            channel_id=slack_msg_data["channel_id"],
+            timestamp=slack_msg_data["timestamp"],
+            team_id=slack_msg_data["team_id"],
+        )
+
+        return cls(
+            message_id=data["message_id"],
+            slack_message=slack_message,
+            trigger_id=data["trigger_id"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+        )
+
+
+@dataclass
+class QueueMessage:
+    """Generic wrapper for all queue message types."""
+
+    message_type: MessageType
+    payload: Union[EmojiGenerationJob, ModalOpeningMessage]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for SQS serialization."""
+        return {
+            "message_type": self.message_type.value,
+            "payload": self.payload.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "QueueMessage":
+        """Create from dictionary."""
+        message_type = MessageType(data["message_type"])
+
+        payload: Union[EmojiGenerationJob, ModalOpeningMessage]
+        if message_type == MessageType.EMOJI_GENERATION:
+            payload = EmojiGenerationJob.from_dict(data["payload"])
+        elif message_type == MessageType.MODAL_OPENING:
+            payload = ModalOpeningMessage.from_dict(data["payload"])
+        else:
+            raise ValueError(f"Unknown message type: {message_type}")
+
+        return cls(message_type=message_type, payload=payload)

--- a/src/emojismith/domain/repositories/job_queue_repository.py
+++ b/src/emojismith/domain/repositories/job_queue_repository.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Protocol, Tuple
 from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+from emojismith.domain.entities.slack_message import SlackMessage
 
 
 class JobQueueRepository(Protocol):
@@ -33,4 +34,10 @@ class JobQueueRepository(Protocol):
 
     async def retry_failed_jobs(self, max_retries: int = 3) -> int:
         """Retry failed jobs that haven't exceeded max retries."""
+        ...
+
+    async def enqueue_modal_opening(
+        self, slack_message: SlackMessage, trigger_id: str
+    ) -> str:
+        """Enqueue a modal opening operation."""
         ...

--- a/src/worker_handler.py
+++ b/src/worker_handler.py
@@ -113,19 +113,71 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             # Parse the SQS message body
             message_body = json.loads(record["body"])
 
-            # Reconstruct the emoji generation job
-            job = EmojiGenerationJob.from_dict(message_body)
+            # Check if this is a new-style wrapped message or legacy job
+            if "message_type" in message_body:
+                # New-style wrapped message
+                from emojismith.domain.entities.queue_message import (
+                    QueueMessage,
+                    MessageType,
+                )
 
-            logger.info(
-                f"Processing emoji generation job: {job.job_id} for user {job.user_id}"
-            )
+                queue_message = QueueMessage.from_dict(message_body)
 
-            # Process the job using async handler
-            import asyncio
+                if queue_message.message_type == MessageType.MODAL_OPENING:
+                    # Handle modal opening
+                    from emojismith.domain.entities.queue_message import (
+                        ModalOpeningMessage,
+                    )
 
-            asyncio.run(emoji_service.process_emoji_generation_job(job))
+                    modal_message = queue_message.payload
+                    assert isinstance(modal_message, ModalOpeningMessage)
 
-            logger.info(f"Successfully completed job: {job.job_id}")
+                    logger.info(
+                        f"Processing modal opening for user {modal_message.slack_message.user_id}"
+                    )
+
+                    import asyncio
+
+                    asyncio.run(
+                        emoji_service.initiate_emoji_creation(
+                            modal_message.slack_message, modal_message.trigger_id
+                        )
+                    )
+
+                    logger.info(
+                        f"Successfully opened modal: {modal_message.message_id}"
+                    )
+
+                elif queue_message.message_type == MessageType.EMOJI_GENERATION:
+                    # Handle emoji generation job
+                    job = queue_message.payload
+                    assert isinstance(job, EmojiGenerationJob)
+
+                    logger.info(
+                        f"Processing emoji generation job: {job.job_id} for user {job.user_id}"
+                    )
+
+                    import asyncio
+
+                    asyncio.run(emoji_service.process_emoji_generation_job(job))
+
+                    logger.info(f"Successfully completed job: {job.job_id}")
+                # Note: All message types are handled above
+                # This else clause is kept for future extensibility
+            else:
+                # Legacy emoji generation job format
+                job = EmojiGenerationJob.from_dict(message_body)
+
+                logger.info(
+                    f"Processing legacy emoji generation job: {job.job_id} for user {job.user_id}"
+                )
+
+                # Process the job using async handler
+                import asyncio
+
+                asyncio.run(emoji_service.process_emoji_generation_job(job))
+
+                logger.info(f"Successfully completed job: {job.job_id}")
 
         except Exception as e:
             logger.exception(f"Failed to process SQS record: {e}")

--- a/tests/unit/application/handlers/test_slack_webhook.py
+++ b/tests/unit/application/handlers/test_slack_webhook.py
@@ -40,6 +40,38 @@ class TestSlackWebhookHandler:
 
         # Assert
         assert result is not None
+        mock_emoji_service.queue_modal_opening.assert_called_once()
+
+    async def test_handles_message_action_payload_fallback_to_sync(
+        self, webhook_handler, mock_emoji_service
+    ):
+        """Test webhook handler falls back to sync modal opening if queue fails."""
+        # Arrange
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "123456789.987654321.abcdefghijklmnopqrstuvwxyz",
+            "user": {"id": "U12345", "name": "testuser"},
+            "channel": {"id": "C67890", "name": "general"},
+            "message": {
+                "text": "Just deployed on Friday afternoon!",
+                "ts": "1234567890.123456",
+                "user": "U98765",
+            },
+            "team": {"id": "T11111"},
+        }
+
+        # Mock queue_modal_opening to fail, should fallback to sync
+        mock_emoji_service.queue_modal_opening.side_effect = ValueError(
+            "Job queue not configured"
+        )
+
+        # Act
+        result = await webhook_handler.handle_message_action(payload)
+
+        # Assert
+        assert result is not None
+        mock_emoji_service.queue_modal_opening.assert_called_once()
         mock_emoji_service.initiate_emoji_creation.assert_called_once()
 
     async def test_handles_modal_submission_payload(

--- a/tests/unit/application/services/test_emoji_service.py
+++ b/tests/unit/application/services/test_emoji_service.py
@@ -187,6 +187,29 @@ class TestEmojiCreationService:
         with pytest.raises(ValueError, match="Malformed modal submission payload"):
             await emoji_service.handle_modal_submission(bad_payload)
 
+    async def test_queue_modal_opening_enqueues_message(
+        self, emoji_service_with_queue, mock_job_queue
+    ):
+        """Test queue_modal_opening enqueues modal opening message."""
+        # Arrange
+        slack_message = SlackMessage(
+            text="Just deployed on Friday afternoon!",
+            user_id="U12345",
+            channel_id="C67890",
+            timestamp="1234567890.123456",
+            team_id="T11111",
+        )
+        trigger_id = "123456789.987654321.abcdefghijklmnopqrstuvwxyz"
+
+        # Act
+        await emoji_service_with_queue.queue_modal_opening(slack_message, trigger_id)
+
+        # Assert - should enqueue a modal opening message
+        mock_job_queue.enqueue_modal_opening.assert_called_once()
+        call_args = mock_job_queue.enqueue_modal_opening.call_args[0]
+        assert call_args[0] == slack_message
+        assert call_args[1] == trigger_id
+
     async def test_processes_emoji_generation_job_end_to_end(
         self,
         emoji_service,


### PR DESCRIPTION
## Summary
- Implement async modal opening to fix `expired_trigger_id` errors
- Webhook handler now returns immediately while processing modal opening asynchronously
- Maintains backward compatibility with existing emoji generation workflow

## Problem Solved
CloudWatch logs showed webhook responses taking 9+ seconds, causing Slack's 3-second trigger_id timeout. This resulted in `expired_trigger_id` errors when trying to open modals.

## Solution
1. **Immediate Response**: Webhook returns 200 OK within milliseconds
2. **Async Processing**: Modal opening queued via SQS for worker Lambda
3. **Graceful Fallback**: Falls back to sync modal opening if queue unavailable

## Technical Implementation
- Added `QueueMessage` wrapper supporting modal opening and emoji generation
- Extended `JobQueueRepository` with `enqueue_modal_opening` method
- Updated worker Lambda to handle both message types with type safety
- Comprehensive test coverage following TDD principles

## Test Plan
- [x] Unit tests for queue message functionality
- [x] Integration tests for webhook handler fallback behavior
- [x] Worker Lambda handles both message types correctly
- [x] Code quality checks (black, flake8, mypy, bandit) pass
- [ ] Manual testing in Slack after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)