### PR TITLE
fix: add missing SQS_QUEUE_URL environment variable to worker Lambda

### DIFF
--- a/infra/stacks/emoji_smith_stack.py
+++ b/infra/stacks/emoji_smith_stack.py
@@ -280,6 +280,7 @@ class EmojiSmithStack(Stack):
             memory_size=1024,  # More memory for image processing
             role=worker_lambda_role,
             environment={
+                "SQS_QUEUE_URL": self.processing_queue.queue_url,
                 "LOG_LEVEL": "INFO",
                 # Secrets injected at deploy time for performance
                 "SLACK_BOT_TOKEN": self.secrets.secret_value_from_json("SLACK_BOT_TOKEN").unsafe_unwrap(),


### PR DESCRIPTION
The worker Lambda was failing to initialize because it was missing the SQS_QUEUE_URL environment variable required by the job queue creation.

This caused the async modal opening to fail silently - the webhook would return 200 OK immediately (good) but the worker couldn't process the queued modal opening message.

🤖 Generated with [Claude Code](https://claude.ai/code)