### PR TITLE
Fix deployment workflow: add webhook package build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,6 +163,16 @@ jobs:
     - name: Install AWS CDK
       run: npm install -g aws-cdk
 
+    - name: Install uv for webhook package build
+      uses: astral-sh/setup-uv@v2
+      with:
+        version: "latest"
+
+    - name: Build webhook package
+      run: |
+        uv sync --group webhook
+        ./scripts/build_webhook_package.sh
+
     - name: Install CDK dependencies
       working-directory: ./infra
       run: |

--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -17,7 +17,7 @@ echo "Using temporary directory: $TEMP_DIR"
 
 # Install dependencies to temp directory
 echo -e "${YELLOW}Installing webhook dependencies...${NC}"
-uv pip sync requirements-webhook.lock --target "$TEMP_DIR" --no-deps
+uv pip install -r requirements-webhook.lock --target "$TEMP_DIR" --no-deps
 
 # Copy webhook source code
 echo -e "${YELLOW}Copying webhook source code...${NC}"


### PR DESCRIPTION
## Summary
- Fixes deployment failure with "Cannot find asset at webhook_package.zip"
- Adds missing webhook package build step to CI/CD pipeline
- Ensures uv environment is properly set up before building webhook package

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test deployment pipeline with webhook package build
- [ ] Confirm CDK can find webhook_package.zip asset

🤖 Generated with [Claude Code](https://claude.ai/code)