### PR TITLE
Fix webhook dependencies: update to current versions

### DIFF
--- a/requirements-webhook.lock
+++ b/requirements-webhook.lock
@@ -1,7 +1,7 @@
 # Minimal webhook dependencies for Lambda package deployment
 # Generated for uv compatibility
-slack-sdk==3.31.1
-boto3==1.35.94
-fastapi==0.115.6
+slack-sdk==3.35.0
+boto3==1.37.3
+fastapi==0.115.12
 mangum==0.19.0
-uvicorn==0.33.0
+uvicorn==0.34.3


### PR DESCRIPTION
## Summary
- Updates webhook dependencies to current versions that match the main environment
- Fixes deployment build failures caused by outdated dependency versions
- Ensures webhook package build can find all required dependencies

## Changes
- slack-sdk: 3.31.1 → 3.35.0  
- boto3: 1.35.94 → 1.37.3
- fastapi: 0.115.6 → 0.115.12
- uvicorn: 0.33.0 → 0.34.3

## Test plan
- [x] Verify updated versions match current dependency group
- [ ] Test webhook package build with updated dependencies
- [ ] Confirm deployment pipeline succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)