### PR TITLE
Fix webhook build timeout: quiet zip output

### DIFF
--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -28,7 +28,8 @@ cp src/__init__.py "$TEMP_DIR/"
 # Create package zip
 echo -e "${YELLOW}Creating webhook package zip...${NC}"
 cd "$TEMP_DIR"
-zip -r webhook_package.zip . -x "*.pyc" "*__pycache__*" "*.git*"
+# Create zip with compression and exclude unnecessary files
+zip -rq webhook_package.zip . -x "*.pyc" "*__pycache__*" "*.git*"
 
 # Move package to project root
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary
- Adds `-q` flag to zip command to reduce verbose output during webhook package build
- Prevents GitHub Actions timeout/logging issues during deployment
- Maintains same package contents but eliminates verbose file listing

## Problem
The webhook package build was timing out during zip creation due to excessive verbose output logging hundreds of files being added to the zip.

## Solution
Use quiet mode (`-q`) for zip command to eliminate verbose file-by-file output while maintaining the same package contents.

## Test plan
- [ ] Verify deployment completes without timeout
- [ ] Confirm webhook package is created successfully
- [ ] Test that CDK can find and deploy the webhook package

🤖 Generated with [Claude Code](https://claude.ai/code)