### PR TITLE
Fix build script: handle execution from project root

### DIFF
--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -32,7 +32,13 @@ cd "$TEMP_DIR"
 zip -rq webhook_package.zip . -x "*.pyc" "*__pycache__*" "*.git*"
 
 # Move package to project root
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -d "scripts" ]; then
+    # Running from project root
+    PROJECT_ROOT=$(pwd)
+else
+    # Running from scripts directory
+    PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
 mv webhook_package.zip "$PROJECT_ROOT/"
 cd "$PROJECT_ROOT"
 


### PR DESCRIPTION
## Summary
- Fixes webhook build script failure in CI/CD pipeline
- Adds logic to detect execution context (project root vs scripts directory)
- Prevents "No such file or directory" error when moving webhook package

## Problem
The webhook build script was failing with:
```
./scripts/build_webhook_package.sh: line 35: cd: ./scripts/..: No such file or directory
```

This happened because the script assumed it was being executed from the `scripts/` directory, but GitHub Actions runs it from the project root.

## Solution
Added conditional logic to detect the current execution context:
- If `scripts` directory exists in current path → running from project root
- Otherwise → running from scripts directory (maintains original behavior)

## Test plan
- [ ] Verify webhook package build completes in CI
- [ ] Test script execution from both project root and scripts directory
- [ ] Confirm CDK deployment can proceed with webhook package

🤖 Generated with [Claude Code](https://claude.ai/code)