### PR TITLE
Fix build script: determine project root before directory changes

### DIFF
--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -11,6 +11,15 @@ NC='\033[0m' # No Color
 
 echo -e "${YELLOW}Building webhook package for Lambda deployment...${NC}"
 
+# Determine project root first (before changing directories)
+if [ -d "scripts" ]; then
+    # Running from project root
+    PROJECT_ROOT=$(pwd)
+else
+    # Running from scripts directory
+    PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
 # Create temporary directory
 TEMP_DIR=$(mktemp -d)
 echo "Using temporary directory: $TEMP_DIR"
@@ -32,13 +41,6 @@ cd "$TEMP_DIR"
 zip -rq webhook_package.zip . -x "*.pyc" "*__pycache__*" "*.git*"
 
 # Move package to project root
-if [ -d "scripts" ]; then
-    # Running from project root
-    PROJECT_ROOT=$(pwd)
-else
-    # Running from scripts directory
-    PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-fi
 mv webhook_package.zip "$PROJECT_ROOT/"
 cd "$PROJECT_ROOT"
 


### PR DESCRIPTION
## Summary
- Fixes webhook build script by moving project root detection to beginning
- Resolves "No such file or directory" error that persisted after previous fix
- Ensures script works correctly from both project root and scripts directory

## Root Cause
The previous fix in PR #146 failed because it checked for the `scripts` directory **after** already changing to `TEMP_DIR`, where no `scripts` directory exists.

**Broken flow:**
1. `cd "$TEMP_DIR"` (line 30)
2. Check `[ -d "scripts" ]` (line 35) ❌ - always fails because we're in temp dir
3. Always defaults to scripts directory logic
4. Fails with "No such file or directory"

## Solution
Move the project root detection to the very beginning, before any directory changes:

**Fixed flow:**
1. Check `[ -d "scripts" ]` while still in original working directory ✅
2. Determine `PROJECT_ROOT` correctly
3. Do all work in `TEMP_DIR`
4. Move package to correct `PROJECT_ROOT`

## Test plan
- [ ] Verify webhook package build completes in CI
- [ ] Confirm CDK deployment can proceed with webhook package
- [ ] Test script execution from both contexts locally

🤖 Generated with [Claude Code](https://claude.ai/code)