### PR TITLE
Fix webhook Lambda: add missing FastAPI dependencies

### DIFF
--- a/requirements-webhook.lock
+++ b/requirements-webhook.lock
@@ -4,3 +4,6 @@ slack-sdk==3.35.0
 boto3==1.37.3
 fastapi==0.115.12
 mangum==0.19.0
+starlette==0.46.2
+pydantic==2.11.7
+typing-extensions==4.14.0

--- a/uv.lock
+++ b/uv.lock
@@ -377,7 +377,6 @@ webhook = [
     { name = "fastapi" },
     { name = "mangum" },
     { name = "slack-sdk" },
-    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -413,7 +412,6 @@ webhook = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "mangum", specifier = ">=0.19.0" },
     { name = "slack-sdk", specifier = ">=3.35.0" },
-    { name = "uvicorn", specifier = ">=0.34.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds missing transitive dependencies required by FastAPI to webhook package
- Resolves Lambda import error that prevented webhook from starting
- Ensures webhook Lambda can successfully handle Slack requests

## Problem
The webhook Lambda was failing on startup with:
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'webhook_handler': No module named 'starlette'
```

The issue was that our minimal `requirements-webhook.lock` only included top-level dependencies but missed the transitive dependencies that FastAPI actually needs to run.

## Root Cause
FastAPI depends on several packages that weren't included in our minimal lock file:
- `starlette` - FastAPI's core ASGI framework
- `pydantic` - Data validation and serialization
- `typing-extensions` - Enhanced type hints

## Solution
Added the missing dependencies to `requirements-webhook.lock`:
```
starlette==0.46.2
pydantic==2.11.7  
typing-extensions==4.14.0
```

## Test plan
- [ ] Verify webhook package builds without errors
- [ ] Confirm webhook Lambda starts successfully in CloudWatch logs
- [ ] Test Slack webhook requests are handled properly
- [ ] Validate no more import errors occur

## Impact
- ✅ Webhook Lambda will start successfully
- ✅ FastAPI will have all required dependencies
- ✅ Slack integration will work properly
- 📦 Slightly larger webhook package (~minimal impact for Lambda)

🤖 Generated with [Claude Code](https://claude.ai/code)