### PR TITLE
Fix webhook Lambda missing FastAPI dependencies

### DIFF
--- a/requirements-webhook.lock
+++ b/requirements-webhook.lock
@@ -1,9 +1,15 @@
-# Minimal webhook dependencies for Lambda package deployment
-# Generated for uv compatibility
-slack-sdk==3.35.0
+# Webhook dependencies for Lambda package deployment
+# Core dependencies with essential transitive deps
 boto3==1.37.3
+botocore==1.37.3
 fastapi==0.115.12
 mangum==0.19.0
+slack-sdk==3.35.0
 starlette==0.46.2
 pydantic==2.11.7
+pydantic-core==2.33.2
 typing-extensions==4.14.0
+annotated-types==0.7.0
+anyio==4.9.0
+sniffio==1.3.1
+idna==3.10


### PR DESCRIPTION
## Summary
- Fixes Lambda import error: "No module named 'pydantic_core'"
- Adds missing FastAPI transitive dependencies to requirements-webhook.lock
- Includes: pydantic-core, typing-extensions, annotated-types, anyio, sniffio, idna

## Test plan
- [ ] Deploy updated webhook package to Lambda
- [ ] Test Slack webhook functionality
- [ ] Verify no more import errors in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.ai/code)