### PR TITLE
Fix webhook Lambda dependencies with accurate versions

### DIFF
--- a/requirements-webhook.lock
+++ b/requirements-webhook.lock
@@ -1,5 +1,5 @@
-# Webhook dependencies for Lambda package deployment
-# Complete dependency tree with all transitive dependencies
+# Webhook dependencies for Lambda package deployment  
+# Generated from: uv pip compile --group webhook pyproject.toml
 boto3==1.37.3
 botocore==1.37.3
 fastapi==0.115.12
@@ -13,10 +13,10 @@ annotated-types==0.7.0
 anyio==4.9.0
 sniffio==1.3.1
 idna==3.10
-typing-inspect==0.9.0
-six==1.16.0
+typing-inspection==0.4.1
+six==1.17.0
 jmespath==1.0.1
-python-dateutil==2.9.0
-urllib3==2.2.3
-certifi==2024.8.30
-s3transfer==0.10.4
+python-dateutil==2.9.0.post0
+urllib3==2.4.0
+certifi==2025.6.15
+s3transfer==0.11.3


### PR DESCRIPTION
## Summary
- Fixes Lambda import error: "No module named 'typing_inspection'"
- Uses exact dependency versions from `uv pip compile --group webhook`
- Corrects typing-inspection version to 0.4.1 (required by pydantic 2.11.7)

## Key Changes
- Updated `typing-inspection` from 0.9.0 to 0.4.1 (correct version for pydantic 2.11.7)
- Updated dependency versions to match exact output from uv compile:
  - `six==1.17.0` (was 1.16.0)
  - `python-dateutil==2.9.0.post0` (was 2.9.0)
  - `urllib3==2.4.0` (was 2.2.3)
  - `certifi==2025.6.15` (was 2024.8.30)
  - `s3transfer==0.11.3` (was 0.10.4)

## Validation
All dependencies tested in Python 3.12 virtual environment and import successfully.

## Test plan
- [ ] Deploy updated webhook package to Lambda
- [ ] Test Slack webhook functionality
- [ ] Verify no more import errors in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.ai/code)