### PR TITLE
Fix webhook Lambda missing aiohttp dependencies

### DIFF
--- a/requirements-webhook.lock
+++ b/requirements-webhook.lock
@@ -1,5 +1,5 @@
 # Webhook dependencies for Lambda package deployment  
-# Generated from: uv pip compile --group webhook pyproject.toml
+# Core dependencies and their transitive dependencies
 boto3==1.37.3
 botocore==1.37.3
 fastapi==0.115.12
@@ -20,3 +20,11 @@ python-dateutil==2.9.0.post0
 urllib3==2.4.0
 certifi==2025.6.15
 s3transfer==0.11.3
+aiohttp==3.12.13
+aiohappyeyeballs==2.6.1
+aiosignal==1.3.2
+attrs==25.3.0
+frozenlist==1.7.0
+multidict==6.4.4
+propcache==0.3.2
+yarl==1.20.1


### PR DESCRIPTION
## Summary
- Fixes Lambda import error: "No module named 'aiohttp'"
- Adds aiohttp and all its transitive dependencies to webhook package
- These dependencies are required by slack-sdk AsyncWebClient

## Dependencies Added
- `aiohttp==3.12.13` - Required by slack-sdk AsyncWebClient
- `aiohappyeyeballs==2.6.1` - aiohttp dependency
- `aiosignal==1.3.2` - aiohttp dependency  
- `attrs==25.3.0` - aiohttp dependency
- `frozenlist==1.7.0` - aiohttp dependency
- `multidict==6.4.4` - aiohttp dependency
- `propcache==0.3.2` - aiohttp dependency
- `yarl==1.20.1` - aiohttp dependency

## Root Cause
The webhook handler uses `slack_sdk.web.async_client.AsyncWebClient` which internally requires aiohttp for async HTTP operations, but we hadn't included these dependencies in the minimal webhook package.

## Test plan
- [ ] Deploy updated webhook package to Lambda
- [ ] Test Slack webhook functionality  
- [ ] Verify no more import errors in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.ai/code)