### PR TITLE
Fix SlackUser data model to handle username field

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -10,6 +10,7 @@ class SlackUser:
 
     id: str
     name: str
+    username: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Fixes TypeError: `SlackUser.__init__() got an unexpected keyword argument 'username'`
- Adds optional `username` field to SlackUser dataclass
- Allows webhook to properly parse Slack message action payloads

## Root Cause
Slack message action payloads include a `username` field in the user object, but our `SlackUser` dataclass only defined `id` and `name` fields. When the webhook tried to parse the payload with `SlackUser(**data["user"])`, it failed because of the unexpected `username` argument.

## Fix
Added `username: Optional[str] = None` to the `SlackUser` dataclass to handle this field from Slack payloads.

## Test plan
- [ ] Deploy updated webhook package to Lambda
- [ ] Test Slack message action from Slack app
- [ ] Verify webhook successfully parses user data and opens modal

🤖 Generated with [Claude Code](https://claude.ai/code)