### PR TITLE
Fix webhook worker compatibility tests

### DIFF
--- a/src/emojismith/application/services/emoji_service.py
+++ b/src/emojismith/application/services/emoji_service.py
@@ -311,7 +311,7 @@ class EmojiCreationService:
                 {
                     **metadata,
                     "user_description": description,
-                    "sharing_preferences": sharing_preferences,
+                    "sharing_preferences": sharing_preferences.to_dict(),
                 }
             )
 

--- a/tests/integration/test_dual_lambda_e2e.py
+++ b/tests/integration/test_dual_lambda_e2e.py
@@ -74,7 +74,7 @@ class TestDualLambdaE2EIntegration:
                         "emoji_description": {"description": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
-                                "selected_option": {"value": "original_channel"}
+                                "selected_option": {"value": "channel"}
                             }
                         },
                         "instruction_visibility": {
@@ -151,9 +151,9 @@ class TestDualLambdaE2EIntegration:
         assert job.channel_id == "C67890"
         assert job.team_id == "T11111"
         assert job.timestamp == "1234567890.123456"
-        assert job.sharing_preferences.share_location.value == "original_channel"
-        assert job.sharing_preferences.instruction_visibility.value == "everyone"
-        assert job.sharing_preferences.image_size.value == "emoji_size"
+        assert job.sharing_preferences.share_location.value == "channel"
+        assert job.sharing_preferences.instruction_visibility.value == "EVERYONE"
+        assert job.sharing_preferences.image_size.value == "EMOJI_SIZE"
 
         # Verify job has required worker fields
         assert job.job_id is not None

--- a/tests/integration/test_dual_lambda_integration.py
+++ b/tests/integration/test_dual_lambda_integration.py
@@ -62,7 +62,7 @@ class TestDualLambdaIntegration:
                         "emoji_description": {"description": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
-                                "selected_option": {"value": "original_channel"}
+                                "selected_option": {"value": "channel"}
                             }
                         },
                         "instruction_visibility": {
@@ -123,9 +123,7 @@ class TestDualLambdaIntegration:
         assert message_body["user_description"] == "facepalm"
         assert message_body["message_text"] == "Just deployed on Friday"
         assert message_body["user_id"] == "U12345"
-        assert (
-            message_body["sharing_preferences"]["share_location"] == "original_channel"
-        )
+        assert message_body["sharing_preferences"]["share_location"] == "channel"
 
     async def test_webhook_handles_invalid_payloads_gracefully(
         self, webhook_handler, mock_slack_repo
@@ -175,7 +173,7 @@ class TestDualLambdaIntegration:
         self, webhook_handler, modal_submission_payload
     ):
         """Test SQS message format is compatible with worker Lambda."""
-        from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+        from shared.domain.entities import EmojiGenerationJob
 
         # Setup mock SQS client for modal submission
         mock_sqs_client = webhook_handler._job_queue._mock_sqs_client
@@ -196,6 +194,6 @@ class TestDualLambdaIntegration:
         assert job.message_text == "Just deployed on Friday"
         assert job.user_id == "U12345"
         assert job.channel_id == "C67890"
-        assert job.sharing_preferences.share_location.value == "original_channel"
-        assert job.sharing_preferences.instruction_visibility.value == "everyone"
-        assert job.sharing_preferences.image_size.value == "emoji_size"
+        assert job.sharing_preferences.share_location.value == "channel"
+        assert job.sharing_preferences.instruction_visibility.value == "EVERYONE"
+        assert job.sharing_preferences.image_size.value == "EMOJI_SIZE"

--- a/tests/integration/test_emoji_sharing_flow.py
+++ b/tests/integration/test_emoji_sharing_flow.py
@@ -147,7 +147,7 @@ class TestEmojiSharingFlow:
                         },
                         "instruction_visibility": {
                             "visibility_select": {
-                                "selected_option": {"value": "submitter_only"}
+                                "selected_option": {"value": "hidden"}
                             }
                         },
                         "image_size": {

--- a/tests/unit/application/services/test_emoji_service.py
+++ b/tests/unit/application/services/test_emoji_service.py
@@ -6,8 +6,8 @@ from io import BytesIO
 from PIL import Image
 from emojismith.application.services.emoji_service import EmojiCreationService
 from emojismith.domain.entities.slack_message import SlackMessage
-from emojismith.domain.services.generation_service import EmojiGenerationService
 from emojismith.domain.entities.generated_emoji import GeneratedEmoji
+from emojismith.domain.services.generation_service import EmojiGenerationService
 
 
 class TestEmojiCreationService:

--- a/tests/unit/application/services/test_emoji_service_modal_sharing.py
+++ b/tests/unit/application/services/test_emoji_service_modal_sharing.py
@@ -76,7 +76,7 @@ class TestEmojiServiceModalSharing:
                         },
                         "share_location": {
                             "share_location_select": {
-                                "selected_option": {"value": "original_channel"}
+                                "selected_option": {"value": "channel"}
                             }
                         },
                         "instruction_visibility": {

--- a/tests/unit/domain/entities/test_emoji_generation_job_sharing.py
+++ b/tests/unit/domain/entities/test_emoji_generation_job_sharing.py
@@ -104,7 +104,7 @@ class TestEmojiGenerationJobSharing:
         """Test job defaults to new thread when not in thread context."""
         # Arrange
         default_prefs = EmojiSharingPreferences.default_for_context(is_in_thread=False)
-        
+
         # Act
         job = EmojiGenerationJob.create_new(
             message_text="Deploy failed",
@@ -130,7 +130,7 @@ class TestEmojiGenerationJobSharing:
         default_prefs = EmojiSharingPreferences.default_for_context(
             is_in_thread=True, thread_ts="123.456"
         )
-        
+
         # Act
         job = EmojiGenerationJob.create_new(
             message_text="Bug in thread",

--- a/tests/unit/domain/value_objects/test_emoji_sharing_preferences.py
+++ b/tests/unit/domain/value_objects/test_emoji_sharing_preferences.py
@@ -50,7 +50,7 @@ class TestEmojiSharingPreferences:
             image_size=ImageSize.EMOJI_SIZE,
             # Missing thread_ts
         )
-        
+
         # Assert
         assert prefs.share_location == ShareLocation.THREAD
         assert prefs.thread_ts is None

--- a/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
+++ b/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
@@ -38,7 +38,9 @@ class TestSQSJobQueue:
     ):
         """Test enqueuing job sends job directly to SQS."""
         # Arrange
-        from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+        from shared.domain.entities import EmojiGenerationJob
+
+        from shared.domain.value_objects import EmojiSharingPreferences
 
         job = EmojiGenerationJob.create_new(
             message_text="Just deployed on Friday!",
@@ -47,6 +49,7 @@ class TestSQSJobQueue:
             channel_id="C67890",
             timestamp="1234567890.123456",
             team_id="T11111",
+            sharing_preferences=EmojiSharingPreferences.default_for_context(),
         )
         mock_sqs_client.send_message.return_value = {
             "MessageId": "msg_123",
@@ -87,13 +90,13 @@ class TestSQSJobQueue:
             "channel_id": "C67890",
             "timestamp": "123.456",
             "team_id": "T11111",
-            "status": "pending",
+            "status": "PENDING",
             "created_at": "2023-01-01T12:00:00+00:00",
             "sharing_preferences": {
-                "share_location": "original_channel",
-                "instruction_visibility": "everyone",
+                "share_location": "channel",
+                "instruction_visibility": "EVERYONE",
                 "include_upload_instructions": True,
-                "image_size": "full_size",
+                "image_size": "EMOJI_SIZE",
                 "thread_ts": None,
             },
         }
@@ -121,7 +124,9 @@ class TestSQSJobQueue:
     async def test_removes_completed_job_from_queue(self, sqs_queue, mock_sqs_client):
         """Test complete_job calls delete_message when receipt_handle is present."""
         # Arrange: create dummy job with receipt_handle
-        from emojismith.domain.entities.emoji_generation_job import EmojiGenerationJob
+        from shared.domain.entities import EmojiGenerationJob
+
+        from shared.domain.value_objects import EmojiSharingPreferences
 
         job = EmojiGenerationJob.create_new(
             message_text="x",
@@ -130,6 +135,7 @@ class TestSQSJobQueue:
             channel_id="C1",
             timestamp="ts",
             team_id="T1",
+            sharing_preferences=EmojiSharingPreferences.default_for_context(),
         )
         receipt_handle = "rh"
 

--- a/tests/unit/infrastructure/slack/test_slack_file_sharing.py
+++ b/tests/unit/infrastructure/slack/test_slack_file_sharing.py
@@ -69,6 +69,7 @@ class TestSlackFileSharingRepository:
             channel_id=channel_id,
             preferences=prefs,
             requester_user_id="U789012",
+            original_message_ts="1234567890.000111",
         )
 
         # Assert
@@ -81,7 +82,7 @@ class TestSlackFileSharingRepository:
         upload_args = mock_slack_client.files_upload_v2.call_args[1]
         assert upload_args["filename"] == "test_emoji.png"
         assert upload_args["channels"] == [channel_id]
-        assert "thread_ts" not in upload_args  # New thread, no thread_ts yet
+        assert upload_args["thread_ts"] == "1234567890.000111"
 
         # Verify instructions were posted
         mock_slack_client.chat_postMessage.assert_called()

--- a/tests/unit/test_worker_handler.py
+++ b/tests/unit/test_worker_handler.py
@@ -26,12 +26,12 @@ def sqs_event() -> Dict[str, Any]:
                         "channel_id": "C123456",
                         "timestamp": "1234567890.123456",
                         "team_id": "T123456",
-                        "status": "pending",
+                        "status": "PENDING",
                         "created_at": "2024-01-01T00:00:00+00:00",
                         "sharing_preferences": {
-                            "share_location": "original_channel",
-                            "instruction_visibility": "everyone",
-                            "image_size": "emoji_size",
+                            "share_location": "channel",
+                            "instruction_visibility": "EVERYONE",
+                            "image_size": "EMOJI_SIZE",
                         },
                     }
                 ),


### PR DESCRIPTION
## Summary
- convert sharing prefs to dict in emoji service
- update tests for new shared domain model enums and imports
- include original message timestamp when creating new threads
- adjust sample job messages for worker expectations

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_685139fcb8608329a231fdec7d23cde6