### PR TITLE
Fix missing shared package in webhook build

### DIFF
--- a/docs/dual-lambda.md
+++ b/docs/dual-lambda.md
@@ -52,6 +52,9 @@ SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account/queue-name
 # Generate webhook package for Lambda deployment
 ./scripts/build_webhook_package.sh
 ```
+The script bundles the `webhook` and `shared` packages along with all runtime
+dependencies so the Lambda can import modules like `shared.domain` without
+errors.
 
 ### CDK Deployment
 ```bash

--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -31,6 +31,7 @@ uv pip install -r requirements-webhook.lock --target "$TEMP_DIR" --no-deps
 # Copy webhook source code
 echo -e "${YELLOW}Copying webhook source code...${NC}"
 cp -r src/webhook "$TEMP_DIR/"
+cp -r src/shared "$TEMP_DIR/"
 cp src/webhook_handler.py "$TEMP_DIR/"
 cp src/__init__.py "$TEMP_DIR/"
 


### PR DESCRIPTION
## Summary
- include shared package when building the webhook Lambda package
- clarify packaging instructions

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: Cannot find implementation or library stub for modules like PIL, slack_sdk)*
- `bandit -r src/`
- `pytest --cov=src tests/` *(fails: ModuleNotFoundError for slack_sdk, boto3, PIL, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851b961a16c8329b1be4540cf70fde6