### PR TITLE
fix: package shared module for webhook lambda

### DIFF
--- a/docs/dual-lambda.md
+++ b/docs/dual-lambda.md
@@ -52,6 +52,8 @@ SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account/queue-name
 # Generate webhook package for Lambda deployment
 ./scripts/build_webhook_package.sh
 ```
+The script now packages the `shared` domain module alongside the webhook code so
+imports resolve correctly when deployed to Lambda.
 
 ### CDK Deployment
 ```bash

--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -31,6 +31,7 @@ uv pip install -r requirements-webhook.lock --target "$TEMP_DIR" --no-deps
 # Copy webhook source code
 echo -e "${YELLOW}Copying webhook source code...${NC}"
 cp -r src/webhook "$TEMP_DIR/"
+cp -r src/shared "$TEMP_DIR/"
 cp src/webhook_handler.py "$TEMP_DIR/"
 cp src/__init__.py "$TEMP_DIR/"
 

--- a/tests/unit/scripts/test_build_webhook_package.py
+++ b/tests/unit/scripts/test_build_webhook_package.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_script_includes_shared_copy():
+    script_path = "scripts/build_webhook_package.sh"
+    with open(script_path) as f:
+        content = f.read()
+    assert (
+        "src/shared" in content
+    ), "webhook package script should include shared module"


### PR DESCRIPTION
## Summary
- include `src/shared` when building the webhook package
- document updated packaging behaviour
- add regression test asserting script copies `shared`

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/unit/scripts/test_build_webhook_package.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6851b961a16c8329b1be4540cf70fde6