### PR TITLE
Fix Slack message parsing

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -37,6 +37,11 @@ class SlackMessage:
     ts: str
     user: str
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SlackMessage":
+        """Create from dictionary, ignoring unknown fields."""
+        return cls(text=data["text"], ts=data["ts"], user=data["user"])
+
 
 @dataclass
 class MessageActionPayload:
@@ -61,7 +66,7 @@ class MessageActionPayload:
             channel=SlackChannel(
                 id=data["channel"]["id"], name=data["channel"].get("name")
             ),
-            message=SlackMessage(**data["message"]),
+            message=SlackMessage.from_dict(data["message"]),
             team=SlackTeam(**data["team"]),
         )
 

--- a/tests/unit/webhook/test_slack_payloads.py
+++ b/tests/unit/webhook/test_slack_payloads.py
@@ -1,0 +1,28 @@
+import pytest
+from webhook.domain.slack_payloads import MessageActionPayload
+
+
+class TestSlackPayloadParsing:
+    """Tests for Slack payload parsing utilities."""
+
+    def test_message_action_payload_parses_message_with_extra_fields(self):
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "trigger123",
+            "user": {"id": "U1", "name": "tester"},
+            "channel": {"id": "C1", "name": "general"},
+            "message": {
+                "type": "message",
+                "text": "example",
+                "ts": "123.456",
+                "user": "U2",
+            },
+            "team": {"id": "T1"},
+        }
+
+        result = MessageActionPayload.from_dict(payload)
+
+        assert result.message.text == "example"
+        assert result.message.ts == "123.456"
+        assert result.message.user == "U2"


### PR DESCRIPTION
## Summary
- ignore extra fields when parsing a Slack message action
- add unit test for message action parsing with extra fields

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `bandit -r src/`
- `mypy src/` *(fails: missing stubs)*
- `pytest --cov=src tests/` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851d1a5b9d88329ab671f40d5f2f047