### PR TITLE
fix: handle extra fields in Slack message action

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -53,15 +53,23 @@ class MessageActionPayload:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "MessageActionPayload":
         """Create from dictionary."""
+        message_data = data["message"]
+        slack_message = SlackMessage(
+            text=message_data["text"],
+            ts=message_data["ts"],
+            user=message_data["user"],
+        )
+
         return cls(
             type=data["type"],
             callback_id=data["callback_id"],
             trigger_id=data["trigger_id"],
             user=SlackUser(**data["user"]),
             channel=SlackChannel(
-                id=data["channel"]["id"], name=data["channel"].get("name")
+                id=data["channel"]["id"],
+                name=data["channel"].get("name"),
             ),
-            message=SlackMessage(**data["message"]),
+            message=slack_message,
             team=SlackTeam(**data["team"]),
         )
 

--- a/tests/unit/webhook/test_slack_payloads.py
+++ b/tests/unit/webhook/test_slack_payloads.py
@@ -1,0 +1,27 @@
+import pytest
+from webhook.domain.slack_payloads import MessageActionPayload
+
+
+class TestMessageActionPayload:
+    def test_from_dict_ignores_extra_message_fields(self) -> None:
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "123",
+            "user": {"id": "U1", "name": "user"},
+            "channel": {"id": "C1", "name": "general"},
+            "message": {
+                "type": "message",
+                "text": "hello",
+                "ts": "123.456",
+                "user": "U1",
+                "extra": "ignore me",
+            },
+            "team": {"id": "T1"},
+        }
+
+        result = MessageActionPayload.from_dict(payload)
+
+        assert result.message.text == "hello"
+        assert result.message.ts == "123.456"
+        assert result.message.user == "U1"


### PR DESCRIPTION
## Summary
- parse message action payload without failing on extraneous message fields
- add unit test for MessageActionPayload parsing

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: import-not-found errors)*
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_6851d1a5b9d88329ab671f40d5f2f047