### PR TITLE
Handle extra fields in Slack message payload

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -37,6 +37,11 @@ class SlackMessage:
     ts: str
     user: str
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SlackMessage":
+        """Create from dictionary, ignoring extra fields."""
+        return cls(text=data["text"], ts=data["ts"], user=data["user"])
+
 
 @dataclass
 class MessageActionPayload:
@@ -61,7 +66,7 @@ class MessageActionPayload:
             channel=SlackChannel(
                 id=data["channel"]["id"], name=data["channel"].get("name")
             ),
-            message=SlackMessage(**data["message"]),
+            message=SlackMessage.from_dict(data["message"]),
             team=SlackTeam(**data["team"]),
         )
 

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -127,3 +127,29 @@ class TestWebhookHandler:
         # Assert
         assert result["status"] == "error"
         assert "Failed to create emoji" in result["error"]
+
+    async def test_message_action_accepts_extra_message_fields(
+        self, webhook_handler, mock_slack_repo
+    ):
+        """Message payloads may include additional fields beyond the schema."""
+
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "TRIG",
+            "user": {"id": "U2", "name": "testuser"},
+            "message": {
+                "text": "extra fields",
+                "user": "U1",
+                "ts": "123.456",
+                "type": "message",
+                "client_msg_id": "abc123",
+            },
+            "channel": {"id": "C1"},
+            "team": {"id": "T1"},
+        }
+
+        result = await webhook_handler.handle_message_action(payload)
+
+        assert result == {"status": "ok"}
+        mock_slack_repo.open_modal.assert_called_once()


### PR DESCRIPTION
## Summary
- add `SlackMessage.from_dict` to strip unknown keys
- parse message action payloads using the new helper
- test message actions with extra Slack message fields

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_6851d1a5b9d88329ab671f40d5f2f047