### PR TITLE
Fix SlackTeam parsing for domain

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -27,6 +27,7 @@ class SlackTeam:
     """Slack team information."""
 
     id: str
+    domain: Optional[str] = None
 
 
 @dataclass
@@ -67,7 +68,10 @@ class MessageActionPayload:
                 id=data["channel"]["id"], name=data["channel"].get("name")
             ),
             message=SlackMessage.from_dict(data["message"]),
-            team=SlackTeam(**data["team"]),
+            team=SlackTeam(
+                id=data["team"]["id"],
+                domain=data["team"].get("domain"),
+            ),
         )
 
 

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -46,6 +46,26 @@ class TestWebhookHandler:
         assert result == {"status": "ok"}
         mock_slack_repo.open_modal.assert_called_once()
 
+    async def test_message_action_with_team_domain(
+        self, webhook_handler, mock_slack_repo
+    ):
+        """Payloads with a team domain should be accepted."""
+
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "TRIG",
+            "user": {"id": "U2", "name": "testuser"},
+            "message": {"text": "domain test", "user": "U1", "ts": "123.456"},
+            "channel": {"id": "C1"},
+            "team": {"id": "T1", "domain": "example"},
+        }
+
+        result = await webhook_handler.handle_message_action(payload)
+
+        assert result == {"status": "ok"}
+        mock_slack_repo.open_modal.assert_called_once()
+
     async def test_handles_modal_submission_queues_emoji_job(
         self, webhook_handler, mock_job_queue
     ):


### PR DESCRIPTION
## Summary
- allow Slack team domain in message action payloads
- cover domain field with a unit test

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`


------
https://chatgpt.com/codex/tasks/task_e_6851e6894ef88329a9e334bac2832d66