### PR TITLE
Fix SlackTeam payload parsing

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -13,6 +13,16 @@ class SlackUser:
     username: Optional[str] = None
     team_id: Optional[str] = None
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SlackUser":
+        """Create from dictionary, ignoring extra fields."""
+        return cls(
+            id=data["id"],
+            name=data.get("name", ""),
+            username=data.get("username"),
+            team_id=data.get("team_id"),
+        )
+
 
 @dataclass
 class SlackChannel:
@@ -27,6 +37,12 @@ class SlackTeam:
     """Slack team information."""
 
     id: str
+    domain: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SlackTeam":
+        """Create from dictionary, ignoring extra fields."""
+        return cls(id=data["id"], domain=data.get("domain"))
 
 
 @dataclass
@@ -62,12 +78,12 @@ class MessageActionPayload:
             type=data["type"],
             callback_id=data["callback_id"],
             trigger_id=data["trigger_id"],
-            user=SlackUser(**data["user"]),
+            user=SlackUser.from_dict(data["user"]),
             channel=SlackChannel(
                 id=data["channel"]["id"], name=data["channel"].get("name")
             ),
             message=SlackMessage.from_dict(data["message"]),
-            team=SlackTeam(**data["team"]),
+            team=SlackTeam.from_dict(data["team"]),
         )
 
 

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -46,6 +46,26 @@ class TestWebhookHandler:
         assert result == {"status": "ok"}
         mock_slack_repo.open_modal.assert_called_once()
 
+    async def test_message_action_accepts_extra_team_fields(
+        self, webhook_handler, mock_slack_repo
+    ):
+        """Team objects may include additional fields beyond the schema."""
+
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "TRIG",
+            "user": {"id": "U2", "name": "testuser"},
+            "message": {"text": "extra team", "user": "U1", "ts": "123.456"},
+            "channel": {"id": "C1"},
+            "team": {"id": "T1", "domain": "example"},
+        }
+
+        result = await webhook_handler.handle_message_action(payload)
+
+        assert result == {"status": "ok"}
+        mock_slack_repo.open_modal.assert_called_once()
+
     async def test_handles_modal_submission_queues_emoji_job(
         self, webhook_handler, mock_job_queue
     ):


### PR DESCRIPTION
## Summary
- tolerate extra fields in Slack team payloads
- add test for extra team fields in webhook handler

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: missing type stubs for several deps)*
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_6851e6894ef88329a9e334bac2832d66