### PR TITLE
Fix Slack team payload parsing

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -27,6 +27,7 @@ class SlackTeam:
     """Slack team information."""
 
     id: str
+    domain: Optional[str] = None
 
 
 @dataclass

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -153,3 +153,23 @@ class TestWebhookHandler:
 
         assert result == {"status": "ok"}
         mock_slack_repo.open_modal.assert_called_once()
+
+    async def test_message_action_accepts_extra_team_fields(
+        self, webhook_handler, mock_slack_repo
+    ):
+        """Team objects may contain additional fields like domain."""
+
+        payload = {
+            "type": "message_action",
+            "callback_id": "create_emoji_reaction",
+            "trigger_id": "TRIG",
+            "user": {"id": "U2", "name": "testuser"},
+            "message": {"text": "hello", "user": "U1", "ts": "123.456"},
+            "channel": {"id": "C1"},
+            "team": {"id": "T1", "domain": "example"},
+        }
+
+        result = await webhook_handler.handle_message_action(payload)
+
+        assert result == {"status": "ok"}
+        mock_slack_repo.open_modal.assert_called_once()


### PR DESCRIPTION
## Summary
- include optional domain in SlackTeam dataclass
- test extra team fields in message action handling

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `python -m mypy src/`
- `bandit -r src/`
- `python -m pytest --cov=src --cov-fail-under=80 tests/`


------
https://chatgpt.com/codex/tasks/task_e_6851e6894ef88329a9e334bac2832d66