### PR TITLE
Remove modal logic from worker

### DIFF
--- a/src/worker_handler.py
+++ b/src/worker_handler.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 import boto3
 from botocore.exceptions import ClientError
 
-from emojismith.app import create_webhook_handler
 from shared.domain.entities import EmojiGenerationJob
 
 # Configure logging
@@ -60,7 +59,6 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # No need to load from Secrets Manager at runtime
 
     # Initialize the emoji service
-    _, _ = create_webhook_handler()  # This sets up dependencies
     from emojismith.application.services.emoji_service import EmojiCreationService
     from emojismith.infrastructure.slack.slack_api import SlackAPIRepository
     from emojismith.infrastructure.openai.openai_api import OpenAIAPIRepository

--- a/tests/unit/test_worker_handler.py
+++ b/tests/unit/test_worker_handler.py
@@ -81,15 +81,13 @@ class TestWorkerHandler:
     )
     def test_lambda_handler_success(self, sqs_event, context):
         """Test successful processing of SQS message."""
-        with patch("src.worker_handler.create_webhook_handler") as mock_create:
-            with patch("asyncio.run") as mock_run:
-                mock_create.return_value = (None, None)
-                mock_run.return_value = None
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = None
 
-                result = handler(sqs_event, context)
+            result = handler(sqs_event, context)
 
-                assert result == {"batchItemFailures": []}
-                mock_run.assert_called_once()
+            assert result == {"batchItemFailures": []}
+            mock_run.assert_called_once()
 
     @patch.dict(
         "os.environ",
@@ -111,14 +109,9 @@ class TestWorkerHandler:
             ]
         }
 
-        with patch("src.worker_handler.create_webhook_handler") as mock_create:
-            mock_create.return_value = (None, None)
+        result = handler(invalid_event, context)
 
-            result = handler(invalid_event, context)
-
-            assert result == {
-                "batchItemFailures": [{"itemIdentifier": "test-message-id"}]
-            }
+        assert result == {"batchItemFailures": [{"itemIdentifier": "test-message-id"}]}
 
     @patch.dict(
         "os.environ",
@@ -130,16 +123,12 @@ class TestWorkerHandler:
     )
     def test_lambda_handler_processing_error(self, sqs_event, context):
         """Test handling of processing errors."""
-        with patch("src.worker_handler.create_webhook_handler") as mock_create:
-            with patch("asyncio.run") as mock_run:
-                mock_create.return_value = (None, None)
-                mock_run.side_effect = Exception("Processing failed")
+        with patch("asyncio.run") as mock_run:
+            mock_run.side_effect = Exception("Processing failed")
 
-                result = handler(sqs_event, context)
+            result = handler(sqs_event, context)
 
-                assert result == {
-                    "batchItemFailures": [{"itemIdentifier": "test-message-id"}]
-                }
+        assert result == {"batchItemFailures": [{"itemIdentifier": "test-message-id"}]}
 
     @patch.dict(
         "os.environ",
@@ -166,14 +155,9 @@ class TestWorkerHandler:
             ]
         }
 
-        with patch("src.worker_handler.create_webhook_handler") as mock_create:
-            mock_create.return_value = (None, None)
+        result = handler(incomplete_event, context)
 
-            result = handler(incomplete_event, context)
-
-            assert result == {
-                "batchItemFailures": [{"itemIdentifier": "test-message-id"}]
-            }
+        assert result == {"batchItemFailures": [{"itemIdentifier": "test-message-id"}]}
 
     def test_secrets_loading_success(self):
         """Test successful loading of secrets from AWS."""
@@ -201,3 +185,23 @@ class TestWorkerHandler:
 
             # Should not raise an exception
             _load_secrets_from_aws()
+
+    @patch.dict(
+        "os.environ",
+        {
+            "AWS_LAMBDA_FUNCTION_NAME": "test-function",
+            "SLACK_BOT_TOKEN": "xoxb-test",
+            "OPENAI_API_KEY": "sk-test",
+        },
+    )
+    def test_worker_does_not_open_modal(self, sqs_event, context):
+        """Worker should not attempt to open Slack modals."""
+        with patch(
+            "emojismith.infrastructure.slack.slack_api.SlackAPIRepository.open_modal"
+        ) as mock_open:
+            with patch("asyncio.run") as mock_run:
+                mock_run.return_value = None
+
+                handler(sqs_event, context)
+
+        mock_open.assert_not_called()


### PR DESCRIPTION
## Summary
- remove unused create_webhook_handler call from worker lambda
- update worker unit tests
- ensure worker does not attempt to open Slack modals

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: Cannot find implementations for third party modules)*
- `bandit -r src/`
- `pytest --cov=src tests/` *(fails: ModuleNotFoundError for slack_sdk, boto3, PIL, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68520533be248329a2a814f62343c292