### PR TITLE
Implement modal name field

### DIFF
--- a/src/shared/domain/entities.py
+++ b/src/shared/domain/entities.py
@@ -13,6 +13,7 @@ class EmojiGenerationJob:
     """Domain entity representing an emoji generation job."""
 
     job_id: str
+    emoji_name: str
     user_description: str
     message_text: str
     user_id: str
@@ -27,6 +28,7 @@ class EmojiGenerationJob:
     @classmethod
     def create_new(
         cls,
+        emoji_name: str,
         user_description: str,
         message_text: str,
         user_id: str,
@@ -39,6 +41,7 @@ class EmojiGenerationJob:
         """Create a new emoji generation job."""
         return cls(
             job_id=str(uuid.uuid4()),
+            emoji_name=emoji_name,
             user_description=user_description,
             message_text=message_text,
             user_id=user_id,
@@ -55,6 +58,7 @@ class EmojiGenerationJob:
         """Convert to dictionary for serialization."""
         return {
             "job_id": self.job_id,
+            "emoji_name": self.emoji_name,
             "user_description": self.user_description,
             "message_text": self.message_text,
             "user_id": self.user_id,
@@ -70,8 +74,13 @@ class EmojiGenerationJob:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "EmojiGenerationJob":
         """Create from dictionary."""
+        emoji_name = data.get("emoji_name")
+        if not emoji_name:
+            emoji_name = data["user_description"].replace(" ", "_").lower()[:32]
+
         return cls(
             job_id=data["job_id"],
+            emoji_name=emoji_name,
             user_description=data["user_description"],
             message_text=data["message_text"],
             user_id=data["user_id"],

--- a/src/webhook/handler.py
+++ b/src/webhook/handler.py
@@ -81,6 +81,11 @@ class WebhookHandler:
                 raise ValueError("Missing emoji description")
             description = desc_block.value
 
+            name_block = state["emoji_name"].name
+            if name_block is None:
+                raise ValueError("Missing emoji name")
+            emoji_name = name_block.value
+
             # Extract share location with None check
             share_select = state["share_location"].share_location_select
             if share_select is None:
@@ -113,6 +118,7 @@ class WebhookHandler:
         )
 
         job = EmojiGenerationJob.create_new(
+            emoji_name=emoji_name,
             user_description=description,
             message_text=metadata["message_text"],
             user_id=metadata["user_id"],
@@ -184,6 +190,19 @@ class WebhookHandler:
                         },
                     },
                     "label": {"type": "plain_text", "text": "Emoji Description"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "emoji_name",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "name",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "Short name (e.g., facepalm)",
+                        },
+                    },
+                    "label": {"type": "plain_text", "text": "Emoji Name"},
                 },
                 {
                     "type": "input",

--- a/tests/integration/test_dual_lambda_e2e.py
+++ b/tests/integration/test_dual_lambda_e2e.py
@@ -72,6 +72,7 @@ class TestDualLambdaE2EIntegration:
                 "state": {
                     "values": {
                         "emoji_description": {"description": {"value": "facepalm"}},
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "channel"}

--- a/tests/integration/test_dual_lambda_integration.py
+++ b/tests/integration/test_dual_lambda_integration.py
@@ -60,6 +60,7 @@ class TestDualLambdaIntegration:
                 "state": {
                     "values": {
                         "emoji_description": {"description": {"value": "facepalm"}},
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "channel"}

--- a/tests/integration/test_emoji_sharing_flow.py
+++ b/tests/integration/test_emoji_sharing_flow.py
@@ -88,6 +88,7 @@ class TestEmojiSharingFlow:
                 "state": {
                     "values": {
                         "emoji_description": {"description": {"value": "facepalm"}},
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "new_thread"}
@@ -140,6 +141,7 @@ class TestEmojiSharingFlow:
                 "state": {
                     "values": {
                         "emoji_description": {"description": {"value": "bug"}},
+                        "emoji_name": {"name": {"value": "bug"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "thread"}

--- a/tests/unit/application/handlers/test_slack_webhook.py
+++ b/tests/unit/application/handlers/test_slack_webhook.py
@@ -53,7 +53,8 @@ class TestSlackWebhookHandler:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
-                        "emoji_description": {"description": {"value": "facepalm"}}
+                        "emoji_description": {"description": {"value": "facepalm"}},
+                        "emoji_name": {"name": {"value": "facepalm"}},
                     }
                 },
                 "private_metadata": '{"message_text": "test", "user_id": "U123"}',

--- a/tests/unit/application/services/test_emoji_service.py
+++ b/tests/unit/application/services/test_emoji_service.py
@@ -101,6 +101,7 @@ class TestEmojiCreationService:
                         "emoji_description": {
                             "description": {"value": "frustrated developer face"}
                         },
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "new_thread"}
@@ -145,6 +146,7 @@ class TestEmojiCreationService:
                         "emoji_description": {
                             "description": {"value": "frustrated developer face"}
                         },
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "new_thread"}
@@ -245,6 +247,7 @@ class TestEmojiCreationService:
         from PIL import Image
 
         job = EmojiGenerationJob.create_new(
+            emoji_name="facepalm_reaction",
             message_text="The deployment failed again 😭",
             user_description="facepalm reaction",
             user_id="U12345",
@@ -300,6 +303,7 @@ class TestEmojiCreationService:
         from PIL import Image
 
         job = EmojiGenerationJob.create_new(
+            emoji_name="test_emoji",
             message_text="Test message",
             user_description="test emoji",
             user_id="U12345",

--- a/tests/unit/application/services/test_emoji_service_modal_sharing.py
+++ b/tests/unit/application/services/test_emoji_service_modal_sharing.py
@@ -74,6 +74,7 @@ class TestEmojiServiceModalSharing:
                         "emoji_description": {
                             "description": {"value": "frustrated developer face"}
                         },
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "channel"}

--- a/tests/unit/domain/entities/test_emoji_generation_job_sharing.py
+++ b/tests/unit/domain/entities/test_emoji_generation_job_sharing.py
@@ -23,6 +23,7 @@ class TestEmojiGenerationJobSharing:
 
         # Act
         job = EmojiGenerationJob.create_new(
+            emoji_name="facepalm",
             message_text="Deploy failed",
             user_description="facepalm",
             user_id="U123",
@@ -46,6 +47,7 @@ class TestEmojiGenerationJobSharing:
             thread_ts="123.456",
         )
         job = EmojiGenerationJob.create_new(
+            emoji_name="bug_emoji",
             message_text="Bug report",
             user_description="bug emoji",
             user_id="U123",
@@ -72,6 +74,7 @@ class TestEmojiGenerationJobSharing:
         # Arrange
         job_dict = {
             "job_id": "test-123",
+            "emoji_name": "facepalm",
             "message_text": "Deploy failed",
             "user_description": "facepalm",
             "user_id": "U123",
@@ -107,6 +110,7 @@ class TestEmojiGenerationJobSharing:
 
         # Act
         job = EmojiGenerationJob.create_new(
+            emoji_name="facepalm",
             message_text="Deploy failed",
             user_description="facepalm",
             user_id="U123",
@@ -133,6 +137,7 @@ class TestEmojiGenerationJobSharing:
 
         # Act
         job = EmojiGenerationJob.create_new(
+            emoji_name="bug_emoji",
             message_text="Bug in thread",
             user_description="bug emoji",
             user_id="U123",

--- a/tests/unit/domain/test_emoji_generation_job.py
+++ b/tests/unit/domain/test_emoji_generation_job.py
@@ -9,6 +9,7 @@ class TestEmojiGenerationJob:
 
     def test_create_new_and_to_from_dict(self):
         job = EmojiGenerationJob.create_new(
+            emoji_name="smile",
             message_text="hello",
             user_description="smile",
             user_id="U1",
@@ -27,6 +28,7 @@ class TestEmojiGenerationJob:
 
     def test_status_transitions(self):
         job = EmojiGenerationJob.create_new(
+            emoji_name="y",
             message_text="x",
             user_description="y",
             user_id="U1",

--- a/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
+++ b/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
@@ -43,6 +43,7 @@ class TestSQSJobQueue:
         from shared.domain.value_objects import EmojiSharingPreferences
 
         job = EmojiGenerationJob.create_new(
+            emoji_name="facepalm",
             message_text="Just deployed on Friday!",
             user_description="facepalm reaction",
             user_id="U12345",
@@ -129,6 +130,7 @@ class TestSQSJobQueue:
         from shared.domain.value_objects import EmojiSharingPreferences
 
         job = EmojiGenerationJob.create_new(
+            emoji_name="y",
             message_text="x",
             user_description="y",
             user_id="U1",

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -78,6 +78,7 @@ class TestWebhookHandler:
                 "state": {
                     "values": {
                         "emoji_description": {"description": {"value": "facepalm"}},
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
                                 "selected_option": {"value": "channel"}


### PR DESCRIPTION
## Summary
- allow users to specify an emoji name in the creation modal
- parse the name in modal submissions and store it in EmojiGenerationJob
- update worker and webhook logic for the new field
- adjust unit and integration tests

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: Cannot find implementation or library stub for several modules)*
- `bandit -r src/`
- `pytest --cov=src tests/` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68520c64438c8329ad0c0792e7b296d7