### PR TITLE
Add emoji name field to modal

### DIFF
--- a/src/emojismith/application/services/emoji_service.py
+++ b/src/emojismith/application/services/emoji_service.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Dict, Any, Optional
 from emojismith.domain.entities.slack_message import SlackMessage
 from shared.domain.entities import EmojiGenerationJob
@@ -121,6 +122,19 @@ class EmojiCreationService:
                 },
                 {
                     "type": "input",
+                    "block_id": "emoji_name",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "name",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "e.g., 'terminal' (will become :terminal:)",
+                        },
+                    },
+                    "label": {"type": "plain_text", "text": "Emoji Name"},
+                },
+                {
+                    "type": "input",
                     "block_id": "emoji_description",
                     "element": {
                         "type": "plain_text_input",
@@ -128,8 +142,8 @@ class EmojiCreationService:
                         "placeholder": {
                             "type": "plain_text",
                             "text": (
-                                "Describe the emoji you want "
-                                "(e.g., facepalm reaction)"
+                                "e.g., 'A retro computer terminal with green text on "
+                                "black background'"
                             ),
                         },
                         "multiline": False,
@@ -255,6 +269,7 @@ class EmojiCreationService:
         state = view.get("state", {}).get("values", {})
         try:
             description = state["emoji_description"]["description"]["value"]
+            emoji_name = state["emoji_name"]["name"]["value"]
             share_location = state["share_location"]["share_location_select"][
                 "selected_option"
             ]["value"]
@@ -263,6 +278,8 @@ class EmojiCreationService:
             ]["value"]
             image_size = state["image_size"]["size_select"]["selected_option"]["value"]
             metadata = json.loads(view.get("private_metadata", "{}"))
+            if not re.fullmatch(r"[a-z0-9_]+", emoji_name):
+                raise KeyError
         except (KeyError, json.JSONDecodeError) as exc:
             self._logger.exception("Malformed modal submission payload")
             raise ValueError("Malformed modal submission payload") from exc
@@ -298,6 +315,7 @@ class EmojiCreationService:
                 team_id=metadata["team_id"],
                 sharing_preferences=sharing_preferences,
                 thread_ts=metadata.get("thread_ts"),
+                emoji_name=emoji_name,
             )
             # Queue job for background processing
             await self._job_queue.enqueue_job(job)
@@ -311,6 +329,7 @@ class EmojiCreationService:
                 {
                     **metadata,
                     "user_description": description,
+                    "emoji_name": emoji_name,
                     "sharing_preferences": sharing_preferences.to_dict(),
                 }
             )
@@ -328,8 +347,12 @@ class EmojiCreationService:
             description=job.user_description,
             context=job.message_text,
         )
-        # Generate emoji name from description, max 32 chars for Slack
-        name = job.user_description.replace(" ", "_").lower()[:32]
+        # Use provided emoji name or derive from description
+        name = (
+            job.emoji_name
+            if job.emoji_name is not None
+            else job.user_description.replace(" ", "_").lower()[:32]
+        )
         emoji = await self._emoji_generator.generate(spec, name)
 
         # Determine workspace type (could be cached or configured)
@@ -430,6 +453,7 @@ class EmojiCreationService:
                 else EmojiSharingPreferences.default_for_context()
             ),
             thread_ts=job_data.get("thread_ts"),
+            emoji_name=job_data.get("emoji_name"),
         )
 
         # Process using the main method

--- a/src/shared/domain/entities.py
+++ b/src/shared/domain/entities.py
@@ -19,6 +19,7 @@ class EmojiGenerationJob:
     channel_id: str
     timestamp: str
     team_id: str
+    emoji_name: Optional[str]
     status: JobStatus
     sharing_preferences: EmojiSharingPreferences
     thread_ts: Optional[str]
@@ -35,6 +36,7 @@ class EmojiGenerationJob:
         team_id: str,
         sharing_preferences: EmojiSharingPreferences,
         thread_ts: Optional[str] = None,
+        emoji_name: Optional[str] = None,
     ) -> "EmojiGenerationJob":
         """Create a new emoji generation job."""
         return cls(
@@ -45,6 +47,7 @@ class EmojiGenerationJob:
             channel_id=channel_id,
             timestamp=timestamp,
             team_id=team_id,
+            emoji_name=emoji_name,
             status=JobStatus.PENDING,
             sharing_preferences=sharing_preferences,
             thread_ts=thread_ts,
@@ -61,6 +64,7 @@ class EmojiGenerationJob:
             "channel_id": self.channel_id,
             "timestamp": self.timestamp,
             "team_id": self.team_id,
+            "emoji_name": self.emoji_name,
             "status": self.status.value,
             "sharing_preferences": self.sharing_preferences.to_dict(),
             "thread_ts": self.thread_ts,
@@ -78,6 +82,7 @@ class EmojiGenerationJob:
             channel_id=data["channel_id"],
             timestamp=data["timestamp"],
             team_id=data["team_id"],
+            emoji_name=data.get("emoji_name"),
             status=JobStatus(data["status"]),
             sharing_preferences=EmojiSharingPreferences.from_dict(
                 data["sharing_preferences"]

--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -115,6 +115,7 @@ class FormBlock:
     """Slack form block."""
 
     description: Optional[FormElement] = None
+    name: Optional[FormElement] = None
     share_location_select: Optional[FormSelect] = None
     visibility_select: Optional[FormSelect] = None
     size_select: Optional[FormSelect] = None
@@ -124,6 +125,7 @@ class FormBlock:
 class FormValues:
     """Slack form values."""
 
+    emoji_name: FormBlock
     emoji_description: FormBlock
     share_location: FormBlock
     instruction_visibility: FormBlock
@@ -175,6 +177,8 @@ class ModalSubmissionPayload:
                 block.description = FormElement(
                     value=block_data["description"]["value"]
                 )
+            if "name" in block_data:
+                block.name = FormElement(value=block_data["name"]["value"])
             if "share_location_select" in block_data:
                 block.share_location_select = FormSelect(
                     selected_option=block_data["share_location_select"][
@@ -192,6 +196,7 @@ class ModalSubmissionPayload:
             return block
 
         form_values = FormValues(
+            emoji_name=create_form_block(values_data["emoji_name"]),
             emoji_description=create_form_block(values_data["emoji_description"]),
             share_location=create_form_block(values_data["share_location"]),
             instruction_visibility=create_form_block(

--- a/tests/integration/test_dual_lambda_e2e.py
+++ b/tests/integration/test_dual_lambda_e2e.py
@@ -71,6 +71,7 @@ class TestDualLambdaE2EIntegration:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {"description": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
@@ -193,6 +194,7 @@ class TestDualLambdaE2EIntegration:
             "channel_id",
             "team_id",
             "timestamp",
+            "emoji_name",
             "sharing_preferences",
         ]
 

--- a/tests/integration/test_dual_lambda_integration.py
+++ b/tests/integration/test_dual_lambda_integration.py
@@ -59,6 +59,7 @@ class TestDualLambdaIntegration:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {"description": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {

--- a/tests/integration/test_emoji_sharing_flow.py
+++ b/tests/integration/test_emoji_sharing_flow.py
@@ -87,6 +87,7 @@ class TestEmojiSharingFlow:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {"description": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {
@@ -139,6 +140,7 @@ class TestEmojiSharingFlow:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "bug"}},
                         "emoji_description": {"description": {"value": "bug"}},
                         "share_location": {
                             "share_location_select": {

--- a/tests/unit/application/handlers/test_slack_webhook.py
+++ b/tests/unit/application/handlers/test_slack_webhook.py
@@ -53,7 +53,8 @@ class TestSlackWebhookHandler:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
-                        "emoji_description": {"description": {"value": "facepalm"}}
+                        "emoji_name": {"name": {"value": "facepalm"}},
+                        "emoji_description": {"description": {"value": "facepalm"}},
                     }
                 },
                 "private_metadata": '{"message_text": "test", "user_id": "U123"}',

--- a/tests/unit/application/services/test_emoji_service.py
+++ b/tests/unit/application/services/test_emoji_service.py
@@ -98,6 +98,7 @@ class TestEmojiCreationService:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {
                             "description": {"value": "frustrated developer face"}
                         },
@@ -142,6 +143,7 @@ class TestEmojiCreationService:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {
                             "description": {"value": "frustrated developer face"}
                         },

--- a/tests/unit/application/services/test_emoji_service_modal_sharing.py
+++ b/tests/unit/application/services/test_emoji_service_modal_sharing.py
@@ -52,6 +52,7 @@ class TestEmojiServiceModalSharing:
 
         # Check that view contains sharing preference blocks
         block_ids = [block.get("block_id") for block in view["blocks"]]
+        assert "emoji_name" in block_ids
         assert "share_location" in block_ids
         assert "instruction_visibility" in block_ids
         assert "image_size" in block_ids
@@ -71,6 +72,7 @@ class TestEmojiServiceModalSharing:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {
                             "description": {"value": "frustrated developer face"}
                         },

--- a/tests/unit/domain/test_emoji_generation_job.py
+++ b/tests/unit/domain/test_emoji_generation_job.py
@@ -16,6 +16,7 @@ class TestEmojiGenerationJob:
             timestamp="ts",
             team_id="T1",
             sharing_preferences=EmojiSharingPreferences.default_for_context(),
+            emoji_name="smile",
         )
         assert job.job_id
         assert job.status == JobStatus.PENDING
@@ -34,6 +35,7 @@ class TestEmojiGenerationJob:
             timestamp="ts",
             team_id="T1",
             sharing_preferences=EmojiSharingPreferences.default_for_context(),
+            emoji_name="y",
         )
         job.mark_as_processing()
         assert job.status == JobStatus.PROCESSING

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -77,6 +77,7 @@ class TestWebhookHandler:
                 "callback_id": "emoji_creation_modal",
                 "state": {
                     "values": {
+                        "emoji_name": {"name": {"value": "facepalm"}},
                         "emoji_description": {"description": {"value": "facepalm"}},
                         "share_location": {
                             "share_location_select": {


### PR DESCRIPTION
## Summary
- include Emoji Name input in modal views
- validate and store emoji_name from modal submissions
- support emoji_name in job entity
- update tests for new field

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_68520c64438c8329ad0c0792e7b296d7