### PR TITLE
Fix duplicate emoji name display in generated response

### DIFF
--- a/tests/integration/test_emoji_sharing_flow.py
+++ b/tests/integration/test_emoji_sharing_flow.py
@@ -121,12 +121,15 @@ class TestEmojiSharingFlow:
         upload_args = mock_slack_client.files_upload_v2.call_args[1]
         assert upload_args["filename"] == "facepalm.png"
         assert upload_args["channels"] == ["C789012"]
-        assert "upload" in upload_args["initial_comment"].lower()
+        # For new thread: no initial_comment on file upload (to avoid duplicates)
+        assert "initial_comment" not in upload_args
 
-        # 6. Verify thread was created
+        # 6. Verify thread was created with upload instructions
         mock_slack_client.chat_postMessage.assert_called_once()
         message_args = mock_slack_client.chat_postMessage.call_args[1]
         assert message_args["channel"] == "C789012"
+        # Instructions should be in the thread message instead
+        assert "upload" in message_args["text"].lower()
 
     async def test_flow_shares_to_existing_thread_when_requested(
         self, emoji_service, mock_slack_client


### PR DESCRIPTION
## Summary
Fixes #168 - eliminates duplicate emoji name display in generated response messages.

**Problem**: When creating new threads, the system was posting the "Generated custom emoji: :name:" message twice:
1. Once in the file upload's `initial_comment`
2. Once in a separate `chat_postMessage` call to create the thread

**Solution**: For new thread creation, removed the `initial_comment` from file upload and included all content (emoji name + instructions) in the single thread message instead.

## Changes
- **Modified file sharing logic**: Conditionally exclude `initial_comment` for new thread scenarios
- **Preserved functionality**: Existing thread sharing still uses `initial_comment` (no change)
- **Updated instruction handling**: Skip additional instruction posting for new threads since they're already in the thread message
- **Enhanced test coverage**: Added specific tests to verify single message posting

## Test Coverage
- ✅ `test_no_duplicate_emoji_messages_for_new_thread` - Verifies no duplicate messages for new threads
- ✅ `test_existing_thread_uses_initial_comment_not_separate_message` - Confirms existing threads work correctly
- ✅ Updated integration test to match new behavior
- ✅ All existing tests continue to pass

## Technical Details
**Before**: New thread creation resulted in duplicate "Generated custom emoji: :name:" text
**After**: Single message in thread with emoji name and instructions (when enabled)

The fix maintains backward compatibility and all existing functionality while eliminating the user experience issue.

🤖 Generated with [Claude Code](https://claude.ai/code)