### PR TITLE
feat: add style preferences modal options

### DIFF
--- a/src/emojismith/domain/value_objects/emoji_specification.py
+++ b/src/emojismith/domain/value_objects/emoji_specification.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from shared.domain.value_objects import EmojiStylePreferences
+
 
 @dataclass(frozen=True)
 class EmojiSpecification:
@@ -7,7 +9,7 @@ class EmojiSpecification:
 
     description: str
     context: str
-    style: str = "cartoon"
+    style_preferences: EmojiStylePreferences = EmojiStylePreferences()
 
     def __post_init__(self) -> None:
         if not self.description:
@@ -18,6 +20,9 @@ class EmojiSpecification:
     def to_prompt(self) -> str:
         """Combine context and description into a single prompt."""
         base = f"{self.context.strip()} {self.description.strip()}"
-        if self.style:
-            return f"{base} in {self.style} style"
-        return base
+        prefs = self.style_preferences
+        return (
+            f"{base} in {prefs.style_type.value} style with "
+            f"{prefs.color_scheme.value} colors "
+            f"{prefs.detail_level.value} detail and {prefs.tone.value} tone"
+        )

--- a/src/shared/domain/entities.py
+++ b/src/shared/domain/entities.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 
-from shared.domain.value_objects import EmojiSharingPreferences, JobStatus
+from shared.domain.value_objects import (
+    EmojiSharingPreferences,
+    JobStatus,
+    EmojiStylePreferences,
+)
 
 
 @dataclass
@@ -23,6 +27,7 @@ class EmojiGenerationJob:
     status: JobStatus
     sharing_preferences: EmojiSharingPreferences
     thread_ts: Optional[str]
+    style_preferences: EmojiStylePreferences | None
     created_at: datetime
 
     @classmethod
@@ -38,6 +43,7 @@ class EmojiGenerationJob:
         team_id: str,
         sharing_preferences: EmojiSharingPreferences,
         thread_ts: Optional[str] = None,
+        style_preferences: EmojiStylePreferences | None = None,
     ) -> "EmojiGenerationJob":
         """Create a new emoji generation job."""
         return cls(
@@ -52,6 +58,7 @@ class EmojiGenerationJob:
             status=JobStatus.PENDING,
             sharing_preferences=sharing_preferences,
             thread_ts=thread_ts,
+            style_preferences=style_preferences,
             created_at=datetime.now(timezone.utc),
         )
 
@@ -69,6 +76,9 @@ class EmojiGenerationJob:
             "status": self.status.value,
             "sharing_preferences": self.sharing_preferences.to_dict(),
             "thread_ts": self.thread_ts,
+            "style_preferences": (
+                self.style_preferences.to_dict() if self.style_preferences else None
+            ),
             "created_at": self.created_at.isoformat(),
         }
 
@@ -89,6 +99,11 @@ class EmojiGenerationJob:
                 data["sharing_preferences"]
             ),
             thread_ts=data.get("thread_ts"),
+            style_preferences=(
+                EmojiStylePreferences.from_dict(data["style_preferences"])
+                if data.get("style_preferences")
+                else None
+            ),
             created_at=datetime.fromisoformat(data["created_at"]),
         )
 

--- a/src/shared/domain/value_objects.py
+++ b/src/shared/domain/value_objects.py
@@ -136,3 +136,108 @@ class EmojiSharingPreferences:
             include_upload_instructions=True,
             thread_ts=thread_ts,
         )
+
+
+class StyleType(Enum):
+    """Visual style for the generated emoji."""
+
+    CARTOON = "cartoon"
+    REALISTIC = "realistic"
+    MINIMALIST = "minimalist"
+    PIXEL_ART = "pixel art"
+
+    @classmethod
+    def from_form_value(cls, value: str) -> "StyleType":
+        mapping = {
+            "cartoon": cls.CARTOON,
+            "realistic": cls.REALISTIC,
+            "minimalist": cls.MINIMALIST,
+            "pixel_art": cls.PIXEL_ART,
+        }
+        return mapping.get(value, cls.CARTOON)
+
+
+class ColorScheme(Enum):
+    """Color scheme preference."""
+
+    BRIGHT = "bright"
+    MUTED = "muted"
+    MONOCHROME = "monochrome"
+    AUTO = "auto"
+
+    @classmethod
+    def from_form_value(cls, value: str) -> "ColorScheme":
+        mapping = {
+            "bright": cls.BRIGHT,
+            "muted": cls.MUTED,
+            "monochrome": cls.MONOCHROME,
+            "auto": cls.AUTO,
+        }
+        return mapping.get(value, cls.AUTO)
+
+
+class DetailLevel(Enum):
+    """Level of detail for the emoji."""
+
+    SIMPLE = "simple"
+    DETAILED = "detailed"
+
+    @classmethod
+    def from_form_value(cls, value: str) -> "DetailLevel":
+        mapping = {"simple": cls.SIMPLE, "detailed": cls.DETAILED}
+        return mapping.get(value, cls.SIMPLE)
+
+
+class Tone(Enum):
+    """Overall tone of the emoji."""
+
+    FUN = "fun"
+    NEUTRAL = "neutral"
+    EXPRESSIVE = "expressive"
+
+    @classmethod
+    def from_form_value(cls, value: str) -> "Tone":
+        mapping = {
+            "fun": cls.FUN,
+            "neutral": cls.NEUTRAL,
+            "expressive": cls.EXPRESSIVE,
+        }
+        return mapping.get(value, cls.FUN)
+
+
+@dataclass(frozen=True)
+class EmojiStylePreferences:
+    """User-selected style preferences for emoji generation."""
+
+    style_type: StyleType = StyleType.CARTOON
+    color_scheme: ColorScheme = ColorScheme.AUTO
+    detail_level: DetailLevel = DetailLevel.SIMPLE
+    tone: Tone = Tone.FUN
+
+    @classmethod
+    def from_form_values(
+        cls, style_type: str, color_scheme: str, detail_level: str, tone: str
+    ) -> "EmojiStylePreferences":
+        return cls(
+            style_type=StyleType.from_form_value(style_type),
+            color_scheme=ColorScheme.from_form_value(color_scheme),
+            detail_level=DetailLevel.from_form_value(detail_level),
+            tone=Tone.from_form_value(tone),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "style_type": self.style_type.value,
+            "color_scheme": self.color_scheme.value,
+            "detail_level": self.detail_level.value,
+            "tone": self.tone.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EmojiStylePreferences":
+        return cls(
+            style_type=StyleType(data["style_type"]),
+            color_scheme=ColorScheme(data["color_scheme"]),
+            detail_level=DetailLevel(data["detail_level"]),
+            tone=Tone(data["tone"]),
+        )

--- a/tests/unit/application/services/test_emoji_service.py
+++ b/tests/unit/application/services/test_emoji_service.py
@@ -112,6 +112,20 @@ class TestEmojiCreationService:
                                 "selected_option": {"value": "everyone"}
                             }
                         },
+                        "style_type": {
+                            "style_select": {"selected_option": {"value": "cartoon"}}
+                        },
+                        "color_scheme": {
+                            "color_scheme_select": {
+                                "selected_option": {"value": "auto"}
+                            }
+                        },
+                        "detail_level": {
+                            "detail_level_select": {
+                                "selected_option": {"value": "simple"}
+                            }
+                        },
+                        "tone": {"tone_select": {"selected_option": {"value": "fun"}}},
                         "image_size": {
                             "size_select": {"selected_option": {"value": "emoji_size"}}
                         },
@@ -157,6 +171,20 @@ class TestEmojiCreationService:
                                 "selected_option": {"value": "everyone"}
                             }
                         },
+                        "style_type": {
+                            "style_select": {"selected_option": {"value": "cartoon"}}
+                        },
+                        "color_scheme": {
+                            "color_scheme_select": {
+                                "selected_option": {"value": "auto"}
+                            }
+                        },
+                        "detail_level": {
+                            "detail_level_select": {
+                                "selected_option": {"value": "simple"}
+                            }
+                        },
+                        "tone": {"tone_select": {"selected_option": {"value": "fun"}}},
                         "image_size": {
                             "size_select": {"selected_option": {"value": "emoji_size"}}
                         },

--- a/tests/unit/application/services/test_emoji_service_modal_sharing.py
+++ b/tests/unit/application/services/test_emoji_service_modal_sharing.py
@@ -53,6 +53,10 @@ class TestEmojiServiceModalSharing:
         # Check that view contains sharing preference blocks
         block_ids = [block.get("block_id") for block in view["blocks"]]
         assert "emoji_name" in block_ids
+        assert "style_type" in block_ids
+        assert "color_scheme" in block_ids
+        assert "detail_level" in block_ids
+        assert "tone" in block_ids
         assert "share_location" in block_ids
         assert "instruction_visibility" in block_ids
         assert "image_size" in block_ids
@@ -86,6 +90,20 @@ class TestEmojiServiceModalSharing:
                                 "selected_option": {"value": "everyone"}
                             }
                         },
+                        "style_type": {
+                            "style_select": {"selected_option": {"value": "cartoon"}}
+                        },
+                        "color_scheme": {
+                            "color_scheme_select": {
+                                "selected_option": {"value": "auto"}
+                            }
+                        },
+                        "detail_level": {
+                            "detail_level_select": {
+                                "selected_option": {"value": "simple"}
+                            }
+                        },
+                        "tone": {"tone_select": {"selected_option": {"value": "fun"}}},
                         "image_size": {
                             "size_select": {"selected_option": {"value": "emoji_size"}}
                         },

--- a/tests/unit/domain/test_emoji_specification.py
+++ b/tests/unit/domain/test_emoji_specification.py
@@ -2,24 +2,27 @@
 
 import pytest
 from emojismith.domain.value_objects import EmojiSpecification
+from shared.domain.value_objects import EmojiStylePreferences, StyleType
 
 
 class TestEmojiSpecification:
     def test_prompt_construction(self) -> None:
+        prefs = EmojiStylePreferences(style_type=StyleType.PIXEL_ART)
         spec = EmojiSpecification(
-            context="Deploy failed", description="facepalm", style="pixel"
+            context="Deploy failed", description="facepalm", style_preferences=prefs
         )
-        assert spec.to_prompt().startswith("Deploy failed facepalm")
-        assert "pixel" in spec.to_prompt()
+        prompt = spec.to_prompt()
+        assert prompt.startswith("Deploy failed facepalm")
+        assert "pixel art" in prompt
 
     def test_prompt_construction_without_style(self) -> None:
         """Test prompt construction with empty style."""
+        prefs = EmojiStylePreferences(style_type=StyleType.CARTOON)
         spec = EmojiSpecification(
-            context="Deploy failed", description="facepalm", style=""
+            context="Deploy failed", description="facepalm", style_preferences=prefs
         )
         prompt = spec.to_prompt()
-        assert prompt == "Deploy failed facepalm"
-        assert "style" not in prompt
+        assert "cartoon" in prompt
 
     def test_requires_fields(self) -> None:
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- add EmojiStylePreferences value object with enums for style options
- store style preferences in EmojiGenerationJob
- include style option blocks in Slack modal
- parse and pass style preferences through emoji creation flow
- update tests for new modal fields and specification

## Testing
- `black src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685249d3f1c883298015a55fc982a252