### PR TITLE
Fix webhook build to include main package

### DIFF
--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -32,6 +32,7 @@ uv pip install -r requirements-webhook.lock --target "$TEMP_DIR" --no-deps
 echo -e "${YELLOW}Copying webhook source code...${NC}"
 cp -r src/webhook "$TEMP_DIR/"
 cp -r src/shared "$TEMP_DIR/"
+cp -r src/emojismith "$TEMP_DIR/"
 cp src/webhook_handler.py "$TEMP_DIR/"
 cp src/__init__.py "$TEMP_DIR/"
 


### PR DESCRIPTION
## Summary
- include `emojismith` package when building the webhook Lambda

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_68525de6037c8329a96a439c1a515a58