### PR TITLE
Add style preferences to webhook modal

### DIFF
--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -119,6 +119,10 @@ class FormBlock:
     share_location_select: Optional[FormSelect] = None
     visibility_select: Optional[FormSelect] = None
     size_select: Optional[FormSelect] = None
+    style_select: Optional[FormSelect] = None
+    color_select: Optional[FormSelect] = None
+    detail_select: Optional[FormSelect] = None
+    tone_select: Optional[FormSelect] = None
 
 
 @dataclass
@@ -130,6 +134,10 @@ class FormValues:
     share_location: FormBlock
     instruction_visibility: FormBlock
     image_size: FormBlock
+    style_type: FormBlock | None = None
+    color_scheme: FormBlock | None = None
+    detail_level: FormBlock | None = None
+    tone: FormBlock | None = None
 
     def __getitem__(self, key: str) -> FormBlock:
         """Allow dict-like access for compatibility."""
@@ -193,6 +201,22 @@ class ModalSubmissionPayload:
                 block.size_select = FormSelect(
                     selected_option=block_data["size_select"]["selected_option"]
                 )
+            if "style_select" in block_data:
+                block.style_select = FormSelect(
+                    selected_option=block_data["style_select"]["selected_option"]
+                )
+            if "color_select" in block_data:
+                block.color_select = FormSelect(
+                    selected_option=block_data["color_select"]["selected_option"]
+                )
+            if "detail_select" in block_data:
+                block.detail_select = FormSelect(
+                    selected_option=block_data["detail_select"]["selected_option"]
+                )
+            if "tone_select" in block_data:
+                block.tone_select = FormSelect(
+                    selected_option=block_data["tone_select"]["selected_option"]
+                )
             return block
 
         form_values = FormValues(
@@ -203,6 +227,10 @@ class ModalSubmissionPayload:
                 values_data["instruction_visibility"]
             ),
             image_size=create_form_block(values_data["image_size"]),
+            style_type=create_form_block(values_data.get("style_type", {})),
+            color_scheme=create_form_block(values_data.get("color_scheme", {})),
+            detail_level=create_form_block(values_data.get("detail_level", {})),
+            tone=create_form_block(values_data.get("tone", {})),
         )
 
         view = ModalView(

--- a/tests/integration/test_dual_lambda_integration.py
+++ b/tests/integration/test_dual_lambda_integration.py
@@ -74,6 +74,16 @@ class TestDualLambdaIntegration:
                         "image_size": {
                             "size_select": {"selected_option": {"value": "emoji_size"}}
                         },
+                        "style_type": {
+                            "style_select": {"selected_option": {"value": "cartoon"}}
+                        },
+                        "color_scheme": {
+                            "color_select": {"selected_option": {"value": "auto"}}
+                        },
+                        "detail_level": {
+                            "detail_select": {"selected_option": {"value": "simple"}}
+                        },
+                        "tone": {"tone_select": {"selected_option": {"value": "fun"}}},
                     }
                 },
                 "private_metadata": json.dumps(

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -92,6 +92,16 @@ class TestWebhookHandler:
                         "image_size": {
                             "size_select": {"selected_option": {"value": "512x512"}}
                         },
+                        "style_type": {
+                            "style_select": {"selected_option": {"value": "cartoon"}}
+                        },
+                        "color_scheme": {
+                            "color_select": {"selected_option": {"value": "auto"}}
+                        },
+                        "detail_level": {
+                            "detail_select": {"selected_option": {"value": "simple"}}
+                        },
+                        "tone": {"tone_select": {"selected_option": {"value": "fun"}}},
                     }
                 },
                 "private_metadata": (


### PR DESCRIPTION
## Summary
- enhance `WebhookHandler` modal with style preference fields
- parse style preference values when queuing jobs
- extend Slack payload models for style data
- update tests for new modal fields

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_6852e2b185ec83298e3970d0a7d9520b