### PR TITLE
Remove unused modal queue message

### DIFF
--- a/src/emojismith/domain/entities/queue_message.py
+++ b/src/emojismith/domain/entities/queue_message.py
@@ -7,72 +7,12 @@ from enum import Enum
 from typing import Dict, Any, Union
 
 from shared.domain.entities import EmojiGenerationJob
-from emojismith.domain.entities.slack_message import SlackMessage
 
 
 class MessageType(Enum):
     """Types of messages that can be queued."""
 
     EMOJI_GENERATION = "emoji_generation"
-    MODAL_OPENING = "modal_opening"
-
-
-@dataclass
-class ModalOpeningMessage:
-    """Message for opening Slack modal asynchronously."""
-
-    message_id: str
-    slack_message: SlackMessage
-    trigger_id: str
-    created_at: datetime
-
-    @classmethod
-    def create_new(
-        cls,
-        slack_message: SlackMessage,
-        trigger_id: str,
-    ) -> "ModalOpeningMessage":
-        """Create a new modal opening message."""
-        return cls(
-            message_id=str(uuid.uuid4()),
-            slack_message=slack_message,
-            trigger_id=trigger_id,
-            created_at=datetime.now(timezone.utc),
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for serialization."""
-        return {
-            "message_id": self.message_id,
-            "slack_message": {
-                "text": self.slack_message.text,
-                "user_id": self.slack_message.user_id,
-                "channel_id": self.slack_message.channel_id,
-                "timestamp": self.slack_message.timestamp,
-                "team_id": self.slack_message.team_id,
-            },
-            "trigger_id": self.trigger_id,
-            "created_at": self.created_at.isoformat(),
-        }
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ModalOpeningMessage":
-        """Create from dictionary."""
-        slack_msg_data = data["slack_message"]
-        slack_message = SlackMessage(
-            text=slack_msg_data["text"],
-            user_id=slack_msg_data["user_id"],
-            channel_id=slack_msg_data["channel_id"],
-            timestamp=slack_msg_data["timestamp"],
-            team_id=slack_msg_data["team_id"],
-        )
-
-        return cls(
-            message_id=data["message_id"],
-            slack_message=slack_message,
-            trigger_id=data["trigger_id"],
-            created_at=datetime.fromisoformat(data["created_at"]),
-        )
 
 
 @dataclass
@@ -80,7 +20,7 @@ class QueueMessage:
     """Generic wrapper for all queue message types."""
 
     message_type: MessageType
-    payload: Union[EmojiGenerationJob, ModalOpeningMessage]
+    payload: EmojiGenerationJob
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for SQS serialization."""
@@ -94,11 +34,9 @@ class QueueMessage:
         """Create from dictionary."""
         message_type = MessageType(data["message_type"])
 
-        payload: Union[EmojiGenerationJob, ModalOpeningMessage]
+        payload: EmojiGenerationJob
         if message_type == MessageType.EMOJI_GENERATION:
             payload = EmojiGenerationJob.from_dict(data["payload"])
-        elif message_type == MessageType.MODAL_OPENING:
-            payload = ModalOpeningMessage.from_dict(data["payload"])
         else:
             raise ValueError(f"Unknown message type: {message_type}")
 

--- a/tests/unit/domain/entities/test_queue_message.py
+++ b/tests/unit/domain/entities/test_queue_message.py
@@ -1,0 +1,23 @@
+from src.emojismith.domain.entities.queue_message import MessageType, QueueMessage
+from shared.domain.entities import EmojiGenerationJob
+from shared.domain.value_objects import EmojiSharingPreferences
+
+
+class TestQueueMessage:
+    def test_round_trip_serialization(self) -> None:
+        job = EmojiGenerationJob.create_new(
+            user_description="desc",
+            emoji_name="name",
+            message_text="msg",
+            user_id="U1",
+            channel_id="C1",
+            timestamp="123",
+            team_id="T1",
+            sharing_preferences=EmojiSharingPreferences.default_for_context(),
+        )
+        msg = QueueMessage(message_type=MessageType.EMOJI_GENERATION, payload=job)
+        data = msg.to_dict()
+        restored = QueueMessage.from_dict(data)
+        assert restored.message_type == MessageType.EMOJI_GENERATION
+        assert isinstance(restored.payload, EmojiGenerationJob)
+        assert restored.payload.job_id == job.job_id


### PR DESCRIPTION
## Summary
- drop ModalOpeningMessage data class
- simplify QueueMessage to only handle EmojiGenerationJob
- add unit test for QueueMessage round-trip

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_685324a0dcd8832997adecc71bd66cc5