### PR TITLE
Fix: Remove unused imports from queue_message.py

### DIFF
--- a/src/emojismith/domain/entities/queue_message.py
+++ b/src/emojismith/domain/entities/queue_message.py
@@ -1,10 +1,8 @@
 """Queue message entities for different operation types."""
 
-import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, Any, Union
+from typing import Dict, Any
 
 from shared.domain.entities import EmojiGenerationJob
 


### PR DESCRIPTION
## Summary
- Remove unused `uuid` import
- Remove unused `datetime`, `timezone` imports  
- Remove unused `Union` import

## Background
These imports were left over from PR #206 which simplified the QueueMessage structure by removing the ModalOpeningMessage class. The imports are no longer needed since:
- No UUIDs are generated in this module anymore
- No datetime operations occur here
- Union type is no longer needed (payload is always EmojiGenerationJob)

## Fix
Removes the unused imports to resolve flake8 F401 violations that were preventing CI from passing.

## Testing
- `flake8 src/ tests/` now passes without errors
- `mypy src/` continues to work correctly
- All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)