### PR TITLE
Unify webhook and worker interfaces

### DIFF
--- a/src/emojismith/application/services/emoji_service.py
+++ b/src/emojismith/application/services/emoji_service.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Dict, Any, Optional
 from shared.domain.entities import EmojiGenerationJob
-from emojismith.domain.repositories.slack_repository import SlackRepository
-from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
+from shared.domain.repositories.slack_repository import SlackRepository
+from shared.domain.repositories.job_queue_repository import JobQueueRepository
 from emojismith.domain.services.generation_service import EmojiGenerationService
 from emojismith.domain.services.emoji_sharing_service import (
     EmojiSharingService,

--- a/src/emojismith/domain/entities/slack_message.py
+++ b/src/emojismith/domain/entities/slack_message.py
@@ -1,31 +1,5 @@
-"""SlackMessage domain entity."""
+"""Re-export SlackMessage from shared domain package."""
 
-from dataclasses import dataclass
+from shared.domain.slack_message import SlackMessage
 
-
-@dataclass(frozen=True)
-class SlackMessage:
-    """Domain entity representing a Slack message for emoji generation."""
-
-    text: str
-    user_id: str
-    channel_id: str
-    timestamp: str
-    team_id: str
-
-    def __post_init__(self) -> None:
-        """Validate required fields and truncate text if needed."""
-        if not self.user_id:
-            raise ValueError("user_id is required")
-        if not self.channel_id:
-            raise ValueError("channel_id is required")
-
-        # Truncate text to 1000 characters if longer
-        if len(self.text) > 1000:
-            object.__setattr__(self, "text", self.text[:1000])
-
-    def get_context_for_ai(self) -> str:
-        """Get message context suitable for AI processing."""
-        # Truncate to 200 characters for AI context
-        context = self.text[:200] if len(self.text) > 200 else self.text
-        return context
+__all__ = ["SlackMessage"]

--- a/src/emojismith/domain/repositories/job_queue_repository.py
+++ b/src/emojismith/domain/repositories/job_queue_repository.py
@@ -1,36 +1,5 @@
-"""Job queue repository protocol for domain layer."""
+"""Re-export JobQueueRepository protocol from shared package."""
 
-from typing import Optional, Protocol, Tuple
-from shared.domain.entities import EmojiGenerationJob
+from shared.domain.repositories.job_queue_repository import JobQueueRepository
 
-
-class JobQueueRepository(Protocol):
-    """Protocol for job queue operations."""
-
-    async def enqueue_job(self, job: EmojiGenerationJob) -> str:
-        """Enqueue a new emoji generation job."""
-        ...
-
-    async def dequeue_job(self) -> Optional[Tuple[EmojiGenerationJob, str]]:
-        """Dequeue the next pending job for processing.
-
-        Returns a tuple of the job and an opaque receipt handle used for
-        acknowledging completion.
-        """
-        ...
-
-    async def complete_job(self, job: EmojiGenerationJob, receipt_handle: str) -> None:
-        """Mark job as completed and remove from queue using the receipt handle."""
-        ...
-
-    async def get_job_status(self, job_id: str) -> Optional[str]:
-        """Get the current status of a job."""
-        ...
-
-    async def update_job_status(self, job_id: str, status: str) -> None:
-        """Update the status of a job."""
-        ...
-
-    async def retry_failed_jobs(self, max_retries: int = 3) -> int:
-        """Retry failed jobs that haven't exceeded max retries."""
-        ...
+__all__ = ["JobQueueRepository"]

--- a/src/emojismith/domain/repositories/slack_repository.py
+++ b/src/emojismith/domain/repositories/slack_repository.py
@@ -1,21 +1,5 @@
-"""Slack repository protocol for domain layer."""
+"""Re-export SlackRepository protocol from shared package."""
 
-from typing import Dict, Any, Protocol
+from shared.domain.repositories.slack_repository import SlackRepository
 
-
-class SlackRepository(Protocol):
-    """Protocol for Slack API operations."""
-
-    async def open_modal(self, trigger_id: str, view: Dict[str, Any]) -> None:
-        """Open modal dialog in Slack."""
-        ...
-
-    async def upload_emoji(self, name: str, image_data: bytes) -> bool:
-        """Upload custom emoji to Slack workspace."""
-        ...
-
-    async def add_emoji_reaction(
-        self, emoji_name: str, channel_id: str, timestamp: str
-    ) -> None:
-        """Add emoji reaction to a message."""
-        ...
+__all__ = ["SlackRepository"]

--- a/src/emojismith/infrastructure/jobs/background_worker.py
+++ b/src/emojismith/infrastructure/jobs/background_worker.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from typing import Any
-from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
+from shared.domain.repositories.job_queue_repository import JobQueueRepository
 from emojismith.application.services.emoji_service import EmojiCreationService
 
 

--- a/src/emojismith/infrastructure/jobs/sqs_job_queue.py
+++ b/src/emojismith/infrastructure/jobs/sqs_job_queue.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import Any, Optional, Tuple
 from shared.domain.entities import EmojiGenerationJob
-from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
+from shared.domain.repositories.job_queue_repository import JobQueueRepository
 
 
 class SQSJobQueue(JobQueueRepository):

--- a/src/emojismith/infrastructure/slack/slack_api.py
+++ b/src/emojismith/infrastructure/slack/slack_api.py
@@ -5,8 +5,10 @@ from typing import Dict, Any
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.errors import SlackApiError
 
+from shared.domain.repositories.slack_repository import SlackRepository
 
-class SlackAPIRepository:
+
+class SlackAPIRepository(SlackRepository):
     """Concrete implementation of SlackRepository using Slack SDK."""
 
     def __init__(self, slack_client: AsyncWebClient) -> None:

--- a/src/shared/domain/__init__.py
+++ b/src/shared/domain/__init__.py
@@ -1,1 +1,6 @@
 """Shared domain models following DDD principles."""
+
+from .entities import EmojiGenerationJob
+from .slack_message import SlackMessage
+
+__all__ = ["EmojiGenerationJob", "SlackMessage"]

--- a/src/shared/domain/repositories/job_queue_repository.py
+++ b/src/shared/domain/repositories/job_queue_repository.py
@@ -1,0 +1,34 @@
+from typing import Optional, Protocol, Tuple, runtime_checkable
+
+from shared.domain.entities import EmojiGenerationJob
+
+
+@runtime_checkable
+class JobQueueProducer(Protocol):
+    """Interface for enqueueing jobs."""
+
+    async def enqueue_job(self, job: EmojiGenerationJob) -> str: ...
+
+
+@runtime_checkable
+class JobQueueConsumer(Protocol):
+    """Interface for consuming jobs from the queue."""
+
+    async def dequeue_job(self) -> Optional[Tuple[EmojiGenerationJob, str]]: ...
+
+    async def complete_job(
+        self, job: EmojiGenerationJob, receipt_handle: str
+    ) -> None: ...
+
+    async def get_job_status(self, job_id: str) -> Optional[str]: ...
+
+    async def update_job_status(self, job_id: str, status: str) -> None: ...
+
+    async def retry_failed_jobs(self, max_retries: int = 3) -> int: ...
+
+
+@runtime_checkable
+class JobQueueRepository(JobQueueProducer, JobQueueConsumer, Protocol):
+    """Full job queue interface."""
+
+    pass

--- a/src/shared/domain/repositories/slack_repository.py
+++ b/src/shared/domain/repositories/slack_repository.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SlackModalRepository(Protocol):
+    """Modal operations for Slack."""
+
+    async def open_modal(self, trigger_id: str, view: Dict[str, Any]) -> None: ...
+
+
+@runtime_checkable
+class SlackEmojiRepository(Protocol):
+    """Emoji-related operations for Slack."""
+
+    async def upload_emoji(self, name: str, image_data: bytes) -> bool: ...
+
+    async def add_emoji_reaction(
+        self, emoji_name: str, channel_id: str, timestamp: str
+    ) -> None: ...
+
+
+@runtime_checkable
+class SlackRepository(SlackModalRepository, SlackEmojiRepository, Protocol):
+    """Complete Slack repository interface."""
+
+    pass

--- a/src/shared/domain/slack_message.py
+++ b/src/shared/domain/slack_message.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class SlackMessage:
+    """Immutable Slack message entity shared across packages."""
+
+    text: str
+    user_id: str
+    channel_id: str
+    timestamp: str
+    team_id: str
+
+    def __post_init__(self) -> None:
+        if not self.user_id:
+            raise ValueError("user_id is required")
+        if not self.channel_id:
+            raise ValueError("channel_id is required")
+        if len(self.text) > 1000:
+            object.__setattr__(self, "text", self.text[:1000])
+
+    def get_context_for_ai(self) -> str:
+        context = self.text[:200] if len(self.text) > 200 else self.text
+        return context
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "text": self.text,
+            "user_id": self.user_id,
+            "channel_id": self.channel_id,
+            "timestamp": self.timestamp,
+            "team_id": self.team_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SlackMessage":
+        return cls(
+            text=data["text"],
+            user_id=data["user_id"],
+            channel_id=data["channel_id"],
+            timestamp=data["timestamp"],
+            team_id=data["team_id"],
+        )

--- a/src/webhook/domain/slack_message.py
+++ b/src/webhook/domain/slack_message.py
@@ -1,35 +1,5 @@
-"""Slack message domain model for webhook package."""
+"""SlackMessage wrapper importing shared entity."""
 
-from dataclasses import dataclass
+from shared.domain.slack_message import SlackMessage
 
-
-@dataclass
-class SlackMessage:
-    """Represents a Slack message for emoji creation."""
-
-    text: str
-    user_id: str
-    channel_id: str
-    timestamp: str
-    team_id: str
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary for serialization."""
-        return {
-            "text": self.text,
-            "user_id": self.user_id,
-            "channel_id": self.channel_id,
-            "timestamp": self.timestamp,
-            "team_id": self.team_id,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "SlackMessage":
-        """Create from dictionary."""
-        return cls(
-            text=data["text"],
-            user_id=data["user_id"],
-            channel_id=data["channel_id"],
-            timestamp=data["timestamp"],
-            team_id=data["team_id"],
-        )
+__all__ = ["SlackMessage"]

--- a/src/webhook/handler.py
+++ b/src/webhook/handler.py
@@ -12,15 +12,15 @@ from shared.domain.value_objects import (
     EmojiStylePreferences,
 )
 from webhook.domain.slack_payloads import MessageActionPayload, ModalSubmissionPayload
-from webhook.repositories.slack_repository import SlackRepository
-from webhook.repositories.job_queue_repository import JobQueueRepository
+from shared.domain.repositories.slack_repository import SlackModalRepository
+from shared.domain.repositories.job_queue_repository import JobQueueProducer
 
 
 class WebhookHandler:
     """Handles Slack webhook events with immediate modal opening."""
 
     def __init__(
-        self, slack_repo: SlackRepository, job_queue: JobQueueRepository
+        self, slack_repo: SlackModalRepository, job_queue: JobQueueProducer
     ) -> None:
         self._slack_repo = slack_repo
         self._job_queue = job_queue

--- a/src/webhook/infrastructure/slack_api.py
+++ b/src/webhook/infrastructure/slack_api.py
@@ -4,10 +4,10 @@ import logging
 from typing import Dict, Any
 from slack_sdk.web.async_client import AsyncWebClient
 
-from webhook.repositories.slack_repository import SlackRepository
+from shared.domain.repositories.slack_repository import SlackModalRepository
 
 
-class SlackAPIRepository(SlackRepository):
+class SlackAPIRepository(SlackModalRepository):
     """Slack API implementation using slack-sdk."""
 
     def __init__(self, client: AsyncWebClient) -> None:

--- a/src/webhook/infrastructure/sqs_job_queue.py
+++ b/src/webhook/infrastructure/sqs_job_queue.py
@@ -4,11 +4,11 @@ import json
 import logging
 import boto3
 
-from webhook.repositories.job_queue_repository import JobQueueRepository
+from shared.domain.repositories.job_queue_repository import JobQueueProducer
 from shared.domain.entities import EmojiGenerationJob
 
 
-class SQSJobQueue(JobQueueRepository):
+class SQSJobQueue(JobQueueProducer):
     """SQS implementation of job queue for webhook package."""
 
     def __init__(self, queue_url: str) -> None:

--- a/src/webhook/repositories/job_queue_repository.py
+++ b/src/webhook/repositories/job_queue_repository.py
@@ -1,13 +1,7 @@
-"""Job queue repository interface for webhook package."""
+"""Compatibility wrapper for job queue producer."""
 
-from abc import ABC, abstractmethod
-from shared.domain.entities import EmojiGenerationJob
+from shared.domain.repositories.job_queue_repository import JobQueueProducer
 
+JobQueueRepository = JobQueueProducer
 
-class JobQueueRepository(ABC):
-    """Repository interface for job queue operations."""
-
-    @abstractmethod
-    async def enqueue_job(self, job: EmojiGenerationJob) -> str:
-        """Enqueue an emoji generation job."""
-        pass
+__all__ = ["JobQueueRepository"]

--- a/src/webhook/repositories/slack_repository.py
+++ b/src/webhook/repositories/slack_repository.py
@@ -1,13 +1,7 @@
-"""Slack repository interface for webhook package."""
+"""Compatibility wrapper for Slack modal repository."""
 
-from abc import ABC, abstractmethod
-from typing import Dict, Any
+from shared.domain.repositories.slack_repository import SlackModalRepository
 
+SlackRepository = SlackModalRepository
 
-class SlackRepository(ABC):
-    """Repository interface for Slack API operations."""
-
-    @abstractmethod
-    async def open_modal(self, trigger_id: str, view: Dict[str, Any]) -> None:
-        """Open a modal dialog in Slack."""
-        pass
+__all__ = ["SlackRepository"]

--- a/tests/unit/domain/services/test_emoji_sharing_service.py
+++ b/tests/unit/domain/services/test_emoji_sharing_service.py
@@ -9,7 +9,7 @@ from emojismith.domain.services.emoji_sharing_service import (
     FileSharingFallbackStrategy,
 )
 from emojismith.domain.entities.generated_emoji import GeneratedEmoji
-from emojismith.domain.entities.slack_message import SlackMessage
+from shared.domain.slack_message import SlackMessage
 from shared.domain.value_objects import (
     EmojiSharingPreferences,
     ShareLocation,

--- a/tests/unit/domain/test_job_queue_repository.py
+++ b/tests/unit/domain/test_job_queue_repository.py
@@ -1,6 +1,10 @@
 """Tests for JobQueueRepository protocol interface."""
 
-from emojismith.domain.repositories.job_queue_repository import JobQueueRepository
+from shared.domain.repositories.job_queue_repository import (
+    JobQueueConsumer,
+    JobQueueProducer,
+    JobQueueRepository,
+)
 
 
 def test_job_queue_repository_protocol_defines_methods():
@@ -11,3 +15,9 @@ def test_job_queue_repository_protocol_defines_methods():
     assert hasattr(JobQueueRepository, "get_job_status")
     assert hasattr(JobQueueRepository, "update_job_status")
     assert hasattr(JobQueueRepository, "retry_failed_jobs")
+
+
+def test_job_queue_interface_composition() -> None:
+    """Combined repository extends producer and consumer."""
+    assert issubclass(JobQueueRepository, JobQueueProducer)
+    assert issubclass(JobQueueRepository, JobQueueConsumer)

--- a/tests/unit/domain/test_slack_message.py
+++ b/tests/unit/domain/test_slack_message.py
@@ -1,7 +1,7 @@
 """Tests for SlackMessage domain entity."""
 
 import pytest
-from emojismith.domain.entities.slack_message import SlackMessage
+from shared.domain.slack_message import SlackMessage
 
 
 class TestSlackMessage:

--- a/tests/unit/domain/test_slack_repository.py
+++ b/tests/unit/domain/test_slack_repository.py
@@ -1,6 +1,10 @@
 """Tests for SlackRepository protocol interface."""
 
-from emojismith.domain.repositories.slack_repository import SlackRepository
+from shared.domain.repositories.slack_repository import (
+    SlackEmojiRepository,
+    SlackModalRepository,
+    SlackRepository,
+)
 
 
 def test_slack_repository_protocol_methods_exist() -> None:
@@ -10,3 +14,9 @@ def test_slack_repository_protocol_methods_exist() -> None:
     assert hasattr(
         SlackRepository, "add_emoji_reaction"
     ), "add_emoji_reaction must be defined"
+
+
+def test_interface_composition() -> None:
+    """SlackRepository should extend both modal and emoji interfaces."""
+    assert issubclass(SlackRepository, SlackModalRepository)
+    assert issubclass(SlackRepository, SlackEmojiRepository)


### PR DESCRIPTION
## Summary
- centralize SlackMessage entity under `shared`
- introduce segmented Slack repository protocols
- introduce producer/consumer job queue protocols
- update imports and implementations across packages
- validate new interfaces via unit tests

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: missing stubs)*
- `bandit -r src/`
- `pytest --cov=src tests/`

------
https://chatgpt.com/codex/tasks/task_e_68533cdbc8408329baf616d845c60a13