### PR TITLE
fix: address PR feedback for environment variable isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,22 @@ aws secretsmanager create-secret --name "emoji-smith/production" --secret-string
 - **"mind blown explosion"** on brilliant ideas
 - **"typing furiously"** on coding discussions
 
+## ⚙️ Configuration
+
+### Environment Variables
+
+| Variable | Description | Default | Values |
+|----------|-------------|---------|---------|
+| `SLACK_BOT_TOKEN` | Slack bot user OAuth token | Required | `xoxb-...` |
+| `SLACK_SIGNING_SECRET` | Slack app signing secret | Required | `...` |
+| `OPENAI_API_KEY` | OpenAI API key for DALL-E | Required | `sk-...` |
+| `OPENAI_CHAT_MODEL` | Chat model for prompt enhancement | `o3` | `o3`, `gpt-4`, `gpt-3.5-turbo` |
+| `EMOJISMITH_FORCE_ENTERPRISE` | Force Enterprise Grid mode | `false` | `true`, `false` |
+| `SQS_QUEUE_URL` | AWS SQS queue URL (production) | None | AWS SQS URL |
+| `AWS_SECRETS_NAME` | AWS Secrets Manager name | None | `emoji-smith/production` |
+
+**Note on `EMOJISMITH_FORCE_ENTERPRISE`**: This environment variable allows you to simulate Enterprise Grid workspace behavior in development/testing. When set to `true`, the bot will attempt direct emoji uploads. Invalid values (anything other than `true` or `false`) will log a warning and default to `false`.
+
 ## 🛠️ Development
 
 ### Feature Branch Workflow

--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -61,6 +61,15 @@ def create_worker_emoji_service() -> EmojiCreationService:
     # Determine workspace type from environment
     workspace_type = WorkspaceType.STANDARD
     force_enterprise = os.getenv("EMOJISMITH_FORCE_ENTERPRISE", "false")
+
+    # Validate environment variable value
+    if force_enterprise.lower() not in ("true", "false"):
+        logger.warning(
+            f"Invalid value for EMOJISMITH_FORCE_ENTERPRISE: '{force_enterprise}'. "
+            "Expected 'true' or 'false'. Defaulting to 'false'."
+        )
+        force_enterprise = "false"
+
     if force_enterprise.lower() == "true":
         workspace_type = WorkspaceType.ENTERPRISE_GRID
 

--- a/src/emojismith/application/services/emoji_service.py
+++ b/src/emojismith/application/services/emoji_service.py
@@ -55,7 +55,7 @@ class EmojiCreationService:
         emoji = await self._emoji_generator.generate(spec, name)
 
         # Get workspace type from sharing service
-        workspace_type = self._sharing_service._workspace_type
+        workspace_type = self._sharing_service.workspace_type
 
         # Create sharing context
         from shared.domain.entities.slack_message import SlackMessage

--- a/src/emojismith/domain/services/emoji_sharing_service.py
+++ b/src/emojismith/domain/services/emoji_sharing_service.py
@@ -68,6 +68,15 @@ class EmojiSharingService:
         """
         self._workspace_type = workspace_type
 
+    @property
+    def workspace_type(self) -> WorkspaceType:
+        """Get the workspace type.
+
+        Returns:
+            The type of Slack workspace.
+        """
+        return self._workspace_type
+
     def determine_sharing_strategy(
         self, context: EmojiSharingContext
     ) -> SharingStrategy:

--- a/tests/unit/domain/services/test_emoji_sharing_service.py
+++ b/tests/unit/domain/services/test_emoji_sharing_service.py
@@ -135,13 +135,13 @@ class TestEmojiSharingService:
     def test_workspace_type_is_stored(self, sharing_service):
         """Test service stores the workspace type provided at initialization."""
         # Default workspace type should be STANDARD
-        assert sharing_service._workspace_type == WorkspaceType.STANDARD
+        assert sharing_service.workspace_type == WorkspaceType.STANDARD
 
         # Test with explicit workspace type
         enterprise_service = EmojiSharingService(
             workspace_type=WorkspaceType.ENTERPRISE_GRID
         )
-        assert enterprise_service._workspace_type == WorkspaceType.ENTERPRISE_GRID
+        assert enterprise_service.workspace_type == WorkspaceType.ENTERPRISE_GRID
 
 
 class TestEmojiSharingContext:


### PR DESCRIPTION
- Add public property 'workspace_type' to EmojiSharingService to avoid private member access
- Add validation for EMOJISMITH_FORCE_ENTERPRISE environment variable with warning for invalid values
- Update README with configuration section documenting all environment variables
- Update tests to use public property instead of private member

🤖 Generated with [Claude Code](https://claude.ai/code)