### PR TITLE
Fix webhook Lambda import error

### DIFF
--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -33,6 +33,7 @@ echo -e "${YELLOW}Copying webhook source code...${NC}"
 cp -r src/webhook "$TEMP_DIR/"
 cp -r src/shared "$TEMP_DIR/"
 cp src/emojismith/infrastructure/aws/webhook_handler.py "$TEMP_DIR/"
+cp src/emojismith/infrastructure/aws/secrets_loader.py "$TEMP_DIR/"
 cp src/__init__.py "$TEMP_DIR/"
 
 # Create package zip

--- a/src/emojismith/infrastructure/aws/webhook_handler.py
+++ b/src/emojismith/infrastructure/aws/webhook_handler.py
@@ -16,7 +16,7 @@ from webhook.infrastructure.sqs_job_queue import SQSJobQueue
 from webhook.domain.webhook_request import WebhookRequest
 from webhook.security.webhook_security_service import WebhookSecurityService
 from webhook.infrastructure.slack_signature_validator import SlackSignatureValidator
-from .secrets_loader import AWSSecretsLoader
+from secrets_loader import AWSSecretsLoader  # type: ignore[import-not-found]
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- Fixes the Lambda runtime import error: `Unable to import module 'webhook_handler': attempted relative import with no known parent package`
- Includes the missing `secrets_loader.py` module in the webhook deployment package
- Updates import path to work with Lambda's flat package structure

## Problem
The webhook Lambda was failing with an import error because:
1. The `secrets_loader.py` module was not included in the deployment package
2. The relative import `.secrets_loader` didn't work in Lambda's package structure

## Solution
1. Added `secrets_loader.py` to the webhook package build script
2. Changed the import from relative to absolute since both files are at the root level in the Lambda package
3. Added mypy ignore comment for the import that only works in the Lambda environment

## Test plan
- [x] Rebuilt webhook package locally with the fix
- [x] Verified both `webhook_handler.py` and `secrets_loader.py` are in the package
- [ ] Deploy to Lambda and verify the import error is resolved

🤖 Generated with [Claude Code](https://claude.ai/code)