### PR TITLE
Remove mock-only tests

### DIFF
--- a/src/emojismith/presentation/web/slack_webhook_api.py
+++ b/src/emojismith/presentation/web/slack_webhook_api.py
@@ -13,11 +13,11 @@ def create_webhook_api(webhook_handler: SlackWebhookHandler) -> FastAPI:
         version="0.1.0",
     )
 
-    @app.get("/health")
+    @app.get("/health")  # type: ignore[misc]
     async def health_check() -> dict:
         return webhook_handler.health_check()
 
-    @app.post("/slack/events")
+    @app.post("/slack/events")  # type: ignore[misc]
     async def slack_events(request: Request) -> dict:
         body = await request.body()
         headers = dict(request.headers)

--- a/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
+++ b/tests/unit/infrastructure/jobs/test_sqs_job_queue.py
@@ -123,45 +123,6 @@ class TestSQSJobQueue:
         assert job.job_id == "job_123"
         assert receipt_handle == "receipt_123"
 
-    async def test_removes_completed_job_from_queue(self, sqs_queue, mock_sqs_client):
-        """Test complete_job calls delete_message when receipt_handle is present."""
-        # Arrange: create dummy job with receipt_handle
-        from shared.domain.entities import EmojiGenerationJob
-
-        from shared.domain.value_objects import EmojiSharingPreferences
-
-        job = EmojiGenerationJob.create_new(
-            message_text="x",
-            user_description="y",
-            emoji_name="y",
-            user_id="U1",
-            channel_id="C1",
-            timestamp="ts",
-            team_id="T1",
-            sharing_preferences=EmojiSharingPreferences.default_for_context(),
-        )
-        receipt_handle = "rh"
-
-        # Act
-        await sqs_queue.complete_job(job, receipt_handle)
-
-        # Assert
-        mock_sqs_client.delete_message.assert_called_with(
-            QueueUrl=sqs_queue.queue_url, ReceiptHandle="rh"
-        )
-
-    async def test_provides_job_status_tracking_methods(self, sqs_queue):
-        """get_job_status, update_job_status, retry_failed_jobs no-ops or defaults."""
-        status = await sqs_queue.get_job_status("jid")
-        assert status is None
-
-        # update_job_status should not error
-        await sqs_queue.update_job_status("jid", "processing")
-
-        # retry_failed_jobs returns 0
-        count = await sqs_queue.retry_failed_jobs(max_retries=5)
-        assert count == 0
-
     async def test_handles_corrupted_job_data_gracefully(
         self, sqs_queue, mock_sqs_client
     ):

--- a/tests/unit/infrastructure/openai/test_openai_api.py
+++ b/tests/unit/infrastructure/openai/test_openai_api.py
@@ -32,17 +32,6 @@ async def test_uses_fallback_model_when_preferred_model_unavailable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generates_emoji_image_from_text_prompt() -> None:
-    client = AsyncMock()
-    client.images.generate.return_value = AsyncMock(
-        data=[AsyncMock(b64_json="aGVsbG8=")]
-    )
-    repo = OpenAIAPIRepository(client)
-    data = await repo.generate_image("prompt")
-    assert isinstance(data, bytes)
-
-
-@pytest.mark.asyncio
 async def test_uses_environment_configured_model_for_chat() -> None:
     """Test that repository respects OPENAI_CHAT_MODEL from environment."""
     import os
@@ -86,28 +75,6 @@ async def test_rejects_image_generation_when_b64_json_is_none() -> None:
     repo = OpenAIAPIRepository(client)
     with pytest.raises(ValueError, match="OpenAI did not return valid image data"):
         await repo.generate_image("prompt")
-
-
-@pytest.mark.asyncio
-async def test_requests_base64_format_from_openai() -> None:
-    """Test that image generation requests base64 format explicitly."""
-    client = AsyncMock()
-    client.images.generate.return_value = AsyncMock(
-        data=[AsyncMock(b64_json="aGVsbG8=")]
-    )
-    repo = OpenAIAPIRepository(client)
-
-    await repo.generate_image("test prompt")
-
-    # Verify the API call includes response_format parameter
-    client.images.generate.assert_called_once_with(
-        model="dall-e-3",
-        prompt="test prompt",
-        n=1,
-        size="1024x1024",
-        response_format="b64_json",
-        quality="standard",
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_worker_handler.py
+++ b/tests/unit/test_worker_handler.py
@@ -102,27 +102,6 @@ class TestWorkerHandler:
             "OPENAI_API_KEY": "sk-test",
         },
     )
-    def test_worker_never_opens_modal(self, sqs_event, context):
-        """Ensure worker emoji service does not open Slack modals."""
-        with patch(
-            "emojismith.infrastructure.aws.worker_handler.create_worker_emoji_service"
-        ) as mock_create:
-            service = Mock(process_emoji_generation_job=Mock())
-            service._slack_repo = Mock(open_modal=Mock())
-            mock_create.return_value = service
-            with patch("asyncio.run") as mock_run:
-                mock_run.return_value = None
-                handler(sqs_event, context)
-                service._slack_repo.open_modal.assert_not_called()
-
-    @patch.dict(
-        "os.environ",
-        {
-            "AWS_LAMBDA_FUNCTION_NAME": "test-function",
-            "SLACK_BOT_TOKEN": "xoxb-test",
-            "OPENAI_API_KEY": "sk-test",
-        },
-    )
     def test_lambda_handler_invalid_json(self, context):
         """Test handling of invalid JSON in message body."""
         invalid_event = {


### PR DESCRIPTION
## Summary
- delete unit tests that only validated mocks
- silence FastAPI decorators to appease mypy

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy --ignore-missing-imports src/`
- `bandit -r src/`
- `pytest --cov=src --cov-fail-under=80 tests/`


------
https://chatgpt.com/codex/tasks/task_e_68562cd6481c832984c819c5455dfe8a