### PR TITLE
Improve OpenAI API tests with recorded HTTP calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pre-commit>=3.5.0",
     "types-requests>=2.31.0",
     "types-boto3>=1.0.0",
+    "respx>=0.21.0",
 ]
 
 [build-system]

--- a/tests/unit/infrastructure/openai/test_openai_api.py
+++ b/tests/unit/infrastructure/openai/test_openai_api.py
@@ -1,140 +1,182 @@
-"""Tests for OpenAIAPIRepository."""
+"""Tests for OpenAIAPIRepository using HTTP-level mocking."""
 
+import base64
+import os
+import json
+
+import httpx
 import pytest
-from unittest.mock import AsyncMock
+import respx
+from openai import AsyncOpenAI
+
 from emojismith.infrastructure.openai.openai_api import OpenAIAPIRepository
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_enhances_prompt_with_ai_assistance() -> None:
-    client = AsyncMock()
-    client.chat.completions.create.return_value = AsyncMock(
-        choices=[AsyncMock(message=AsyncMock(content="ok"))]
+    model_route = respx.get("https://api.openai.com/v1/models/o3").respond(
+        200, json={"id": "o3"}
     )
-    repo = OpenAIAPIRepository(client)
+    chat_route = respx.post("https://api.openai.com/v1/chat/completions").respond(
+        200,
+        json={
+            "choices": [
+                {
+                    "message": {
+                        "content": "ok",
+                        "role": "assistant",
+                    }
+                }
+            ]
+        },
+    )
+
+    client = AsyncOpenAI(api_key="sk-test")
+    repo = OpenAIAPIRepository(client, model="o3")
     result = await repo.enhance_prompt("ctx", "desc")
+
     assert result == "ok"
-    client.chat.completions.create.assert_called_once()
+    assert model_route.called
+    assert chat_route.called
+    sent_json = json.loads(chat_route.calls[0].request.content.decode())
+    assert sent_json["model"] == "o3"
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_uses_fallback_model_when_preferred_model_unavailable() -> None:
-    client = AsyncMock()
-    client.models.retrieve = AsyncMock(side_effect=[Exception(), None])
-    client.chat.completions.create.return_value = AsyncMock(
-        choices=[AsyncMock(message=AsyncMock(content="fine"))]
+    respx.get("https://api.openai.com/v1/models/o3").respond(500)
+    respx.get("https://api.openai.com/v1/models/gpt-4").respond(
+        200, json={"id": "gpt-4"}
     )
+
+    chat_route = respx.post("https://api.openai.com/v1/chat/completions").respond(
+        200,
+        json={"choices": [{"message": {"content": "fine"}}]},
+    )
+
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client, model="o3", fallback_models=["gpt-4"])
     result = await repo.enhance_prompt("ctx", "desc")
+
     assert result == "fine"
-    client.chat.completions.create.assert_called_once()
-    assert client.chat.completions.create.call_args.kwargs["model"] == "gpt-4"
+    assert chat_route.called
+    sent_json = json.loads(chat_route.calls[0].request.content.decode())
+    assert sent_json["model"] == "gpt-4"
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_generates_emoji_image_from_text_prompt() -> None:
-    client = AsyncMock()
-    client.images.generate.return_value = AsyncMock(
-        data=[AsyncMock(b64_json="aGVsbG8=")]
+    png_b64 = base64.b64encode(b"test").decode()
+    respx.post("https://api.openai.com/v1/images/generations").respond(
+        200,
+        json={"data": [{"b64_json": png_b64}]},
     )
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client)
     data = await repo.generate_image("prompt")
     assert isinstance(data, bytes)
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_uses_environment_configured_model_for_chat() -> None:
-    """Test that repository respects OPENAI_CHAT_MODEL from environment."""
-    import os
-
-    # Set environment variable
+    """Repository should respect OPENAI_CHAT_MODEL environment variable."""
     os.environ["OPENAI_CHAT_MODEL"] = "gpt-4-turbo"
 
-    client = AsyncMock()
-    client.models.retrieve = AsyncMock(return_value=None)
-    client.chat.completions.create.return_value = AsyncMock(
-        choices=[AsyncMock(message=AsyncMock(content="response"))]
+    respx.get("https://api.openai.com/v1/models/gpt-4-turbo").respond(
+        200, json={"id": "gpt-4-turbo"}
+    )
+    chat_route = respx.post("https://api.openai.com/v1/chat/completions").respond(
+        200,
+        json={"choices": [{"message": {"content": "response"}}]},
     )
 
-    # Create repository with environment model
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client, model=os.getenv("OPENAI_CHAT_MODEL", "o3"))
     result = await repo.enhance_prompt("context", "description")
 
-    # Verify it uses the environment-configured model
     assert result == "response"
-    client.chat.completions.create.assert_called_once()
-    assert client.chat.completions.create.call_args.kwargs["model"] == "gpt-4-turbo"
+    assert chat_route.called
+    sent_json = json.loads(chat_route.calls[0].request.content.decode())
+    assert sent_json["model"] == "gpt-4-turbo"
 
-    # Clean up
     del os.environ["OPENAI_CHAT_MODEL"]
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_rejects_image_generation_when_no_data_returned() -> None:
-    client = AsyncMock()
-    client.images.generate.return_value = AsyncMock(data=[])
+    respx.post("https://api.openai.com/v1/images/generations").respond(
+        200, json={"data": []}
+    )
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client)
     with pytest.raises(ValueError):
         await repo.generate_image("p")
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_rejects_image_generation_when_b64_json_is_none() -> None:
-    """Test that None b64_json is handled gracefully."""
-    client = AsyncMock()
-    client.images.generate.return_value = AsyncMock(data=[AsyncMock(b64_json=None)])
+    """Gracefully handle null b64_json from API."""
+    respx.post("https://api.openai.com/v1/images/generations").respond(
+        200,
+        json={"data": [{"b64_json": None}]},
+    )
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client)
     with pytest.raises(ValueError, match="OpenAI did not return valid image data"):
         await repo.generate_image("prompt")
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_requests_base64_format_from_openai() -> None:
-    """Test that image generation requests base64 format explicitly."""
-    client = AsyncMock()
-    client.images.generate.return_value = AsyncMock(
-        data=[AsyncMock(b64_json="aGVsbG8=")]
+    """Image generation should request b64_json format."""
+    png_b64 = base64.b64encode(b"hi").decode()
+    route = respx.post("https://api.openai.com/v1/images/generations").respond(
+        200,
+        json={"data": [{"b64_json": png_b64}]},
     )
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client)
 
     await repo.generate_image("test prompt")
 
-    # Verify the API call includes response_format parameter
-    client.images.generate.assert_called_once_with(
-        model="dall-e-3",
-        prompt="test prompt",
-        n=1,
-        size="1024x1024",
-        response_format="b64_json",
-        quality="standard",
-    )
+    assert route.called
+    req_json = json.loads(route.calls[0].request.content.decode())
+    assert req_json["response_format"] == "b64_json"
 
 
 @pytest.mark.asyncio
+@respx.mock
 async def test_falls_back_to_dalle2_when_dalle3_fails() -> None:
-    """Test that image generation falls back to DALL-E 2 when DALL-E 3 fails."""
-    client = AsyncMock()
+    """Image generation should retry with DALL-E 2 when DALL-E 3 fails."""
+    call_count = {"i": 0}
 
-    # First call (DALL-E 3) fails
-    client.images.generate.side_effect = [
-        Exception("DALL-E 3 not available"),
-        AsyncMock(data=[AsyncMock(b64_json="aGVsbG8=")]),  # DALL-E 2 succeeds
-    ]
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["i"] += 1
+        if call_count["i"] <= 3:
+            raise httpx.HTTPError("dalle3 failed")
+        return httpx.Response(
+            200,
+            json={"data": [{"b64_json": base64.b64encode(b"img").decode()}]},
+        )
 
+    respx.post("https://api.openai.com/v1/images/generations").mock(side_effect=handler)
+
+    client = AsyncOpenAI(api_key="sk-test")
     repo = OpenAIAPIRepository(client)
     result = await repo.generate_image("test prompt")
 
-    # Should have called both models
-    assert client.images.generate.call_count == 2
-
-    # First call should be DALL-E 3
-    first_call = client.images.generate.call_args_list[0]
-    assert first_call.kwargs["model"] == "dall-e-3"
-
-    # Second call should be DALL-E 2
-    second_call = client.images.generate.call_args_list[1]
-    assert second_call.kwargs["model"] == "dall-e-2"
-    assert second_call.kwargs["size"] == "512x512"  # DALL-E 2 max size
-
-    # Should return the result
+    calls = respx.calls
+    assert len(calls) >= 4
+    first_json = json.loads(calls[0].request.content.decode())
+    last_json = json.loads(calls[-1].request.content.decode())
+    assert first_json["model"] == "dall-e-3"
+    assert last_json["model"] == "dall-e-2"
+    assert last_json["size"] == "512x512"
     assert isinstance(result, bytes)

--- a/uv.lock
+++ b/uv.lock
@@ -367,6 +367,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "respx" },
     { name = "types-boto3" },
     { name = "types-requests" },
 ]
@@ -399,6 +400,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "slack-bolt", specifier = ">=1.18.0" },
     { name = "types-boto3", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
@@ -1130,6 +1132,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `respx` dev dependency
- rewrite OpenAI API tests to use `respx` for HTTP-level mocking
- update lockfile

## Testing
- `black --check src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src --cov-fail-under=80 tests`


------
https://chatgpt.com/codex/tasks/task_e_6856391eb32c832998a7f2910ffa6315