### PR TITLE
Fix #260 refactor test naming

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203, W503
+extend-ignore = E203, W503, PT011
 exclude = .git,__pycache__,build,dist,.venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: test-naming
+        name: check test naming
+        entry: python scripts/check_test_naming.py
+        language: system
+        types: [python]
+
+  - repo: local
+    hooks:
       - id: mypy
         name: mypy
         entry: uv run mypy

--- a/docs/testing/testing-guidelines.md
+++ b/docs/testing/testing-guidelines.md
@@ -138,7 +138,8 @@ tests/
 ### Naming Conventions
 - Test files: `test_<module_name>.py`
 - Test classes: `Test<ClassName>`
-- Test methods: `test_<scenario>_<expected_outcome>`
+- Test methods: `test_<unit_under_test>_<scenario>_<expected_outcome>`
+  - Example: `test_slack_client_when_rate_limited_retries_three_times`
 
 ## Common Anti-Patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "black>=23.0.0",
     "flake8>=6.0.0",
+    "flake8-pytest-style>=2.1.0",
     "mypy>=1.7.0",
     "bandit>=1.7.0",
     "pre-commit>=3.5.0",

--- a/scripts/check_test_naming.py
+++ b/scripts/check_test_naming.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Fail if any test function name does not follow naming convention."""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def collect_test_functions(path: Path) -> list[tuple[str, int]]:
+    """Return list of (name, line) for test functions in file."""
+    functions: list[tuple[str, int]] = []
+    try:
+        tree = ast.parse(path.read_text())
+    except Exception as exc:  # pragma: no cover - syntax errors should fail
+        raise RuntimeError(f"Failed to parse {path}: {exc}") from exc
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+            functions.append((node.name, node.lineno))
+    return functions
+
+
+def main(paths: list[str]) -> int:
+    base_paths = [Path(p) for p in paths]
+    if not base_paths:
+        base_paths = [Path("tests")]
+
+    violations: list[str] = []
+    for base in base_paths:
+        files = [base] if base.is_file() else list(base.rglob("test_*.py"))
+        for file in files:
+            for name, line in collect_test_functions(file):
+                if name.count("_") < 3:  # test + at least unit + scenario + result
+                    violations.append(f"{file}:{line} {name}")
+    if violations:
+        print("Test naming violations found:")
+        for v in violations:
+            print(v)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/infrastructure/openai/test_openai_api.py
+++ b/tests/unit/infrastructure/openai/test_openai_api.py
@@ -6,7 +6,7 @@ from emojismith.infrastructure.openai.openai_api import OpenAIAPIRepository
 
 
 @pytest.mark.asyncio
-async def test_enhances_prompt_with_ai_assistance() -> None:
+async def test_builds_contextual_prompt_for_emoji_generation() -> None:
     client = AsyncMock()
     client.chat.completions.create.return_value = AsyncMock(
         choices=[AsyncMock(message=AsyncMock(content="ok"))]
@@ -18,7 +18,7 @@ async def test_enhances_prompt_with_ai_assistance() -> None:
 
 
 @pytest.mark.asyncio
-async def test_uses_fallback_model_when_preferred_model_unavailable() -> None:
+async def test_enhance_prompt_uses_fallback_model_when_preferred_unavailable() -> None:
     client = AsyncMock()
     client.models.retrieve = AsyncMock(side_effect=[Exception(), None])
     client.chat.completions.create.return_value = AsyncMock(
@@ -32,7 +32,7 @@ async def test_uses_fallback_model_when_preferred_model_unavailable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_uses_environment_configured_model_for_chat() -> None:
+async def test_enhance_prompt_respects_environment_model_setting() -> None:
     """Test that repository respects OPENAI_CHAT_MODEL from environment."""
     import os
 
@@ -59,7 +59,7 @@ async def test_uses_environment_configured_model_for_chat() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rejects_image_generation_when_no_data_returned() -> None:
+async def test_generate_image_raises_when_no_data_returned() -> None:
     client = AsyncMock()
     client.images.generate.return_value = AsyncMock(data=[])
     repo = OpenAIAPIRepository(client)
@@ -68,7 +68,7 @@ async def test_rejects_image_generation_when_no_data_returned() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rejects_image_generation_when_b64_json_is_none() -> None:
+async def test_generate_image_raises_when_b64_json_missing() -> None:
     """Test that None b64_json is handled gracefully."""
     client = AsyncMock()
     client.images.generate.return_value = AsyncMock(data=[AsyncMock(b64_json=None)])
@@ -78,7 +78,7 @@ async def test_rejects_image_generation_when_b64_json_is_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_falls_back_to_dalle2_when_dalle3_fails() -> None:
+async def test_generate_image_falls_back_to_dalle2_on_dalle3_error() -> None:
     """Test that image generation falls back to DALL-E 2 when DALL-E 3 fails."""
     client = AsyncMock()
 

--- a/tests/unit/infrastructure/openai/test_openai_api_http.py
+++ b/tests/unit/infrastructure/openai/test_openai_api_http.py
@@ -8,7 +8,7 @@ from emojismith.infrastructure.openai.openai_api import OpenAIAPIRepository
 
 
 @pytest.mark.asyncio
-async def test_enhance_prompt_recorded() -> None:
+async def test_http_enhance_prompt_returns_recorded_response() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.startswith("/v1/models"):
             return httpx.Response(200, json={})
@@ -30,7 +30,7 @@ async def test_enhance_prompt_recorded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_image_fallback() -> None:
+async def test_http_generate_image_uses_fallback_on_failure() -> None:
     calls = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -58,7 +58,7 @@ async def test_generate_image_fallback() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_image_handles_invalid_response() -> None:
+async def test_http_generate_image_raises_on_invalid_response() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.startswith("/v1/models"):
             return httpx.Response(200, json={})

--- a/uv.lock
+++ b/uv.lock
@@ -362,6 +362,7 @@ dev = [
     { name = "bandit" },
     { name = "black" },
     { name = "flake8" },
+    { name = "flake8-pytest-style" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -389,6 +390,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "flake8-pytest-style", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "mangum", specifier = ">=0.17.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
@@ -451,6 +453,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/c4/5842fc9fc94584c455543540af62fd9900faade32511fab650e9891ec225/flake8-7.2.0.tar.gz", hash = "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426", size = 48177, upload-time = "2025-03-29T20:08:39.329Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/5c/0627be4c9976d56b1217cb5187b7504e7fd7d3503f8bfd312a04077bd4f7/flake8-7.2.0-py2.py3-none-any.whl", hash = "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343", size = 57786, upload-time = "2025-03-29T20:08:37.902Z" },
+]
+
+[[package]]
+name = "flake8-plugin-utils"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/14/53727a2bc5bbda1e1f7e266e0e2d2718e5eb6c943a1e8cc2b33e5af002e0/flake8-plugin-utils-1.3.3.tar.gz", hash = "sha256:39f6f338d038b301c6fd344b06f2e81e382b68fa03c0560dff0d9b1791a11a2c", size = 10459, upload-time = "2023-06-26T16:42:20.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a7/23c012c9becaacb24e9ba8e359e48db5f96982d505e38a3e7003902c5b9f/flake8_plugin_utils-1.3.3-py3-none-any.whl", hash = "sha256:e4848c57d9d50f19100c2d75fa794b72df068666a9041b4b0409be923356a3ed", size = 9664, upload-time = "2023-06-26T16:42:23.939Z" },
+]
+
+[[package]]
+name = "flake8-pytest-style"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flake8-plugin-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b2/f959c7a1e60592c2b828e88a80a0d54a88f68055233906d8fbdd5babe43e/flake8_pytest_style-2.1.0.tar.gz", hash = "sha256:fee6befdb5915d600ef24e38d48a077d0dcffb032945ae0169486e7ff8a1079a", size = 17334, upload-time = "2025-01-10T16:02:58.537Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/9a/15831baaae4ef0d003c9d789fef25b6333c095e15d4e9983dfaf20546108/flake8_pytest_style-2.1.0-py3-none-any.whl", hash = "sha256:a0d6dddcd533bfc13f19b8445907be0330c5e6ccf7090bcd9d5fa5a0b1b65e71", size = 22264, upload-time = "2025-01-10T16:02:56.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- rename OpenAI API tests to follow clearer naming
- add custom script to enforce test naming conventions
- run script via pre-commit hook
- document test naming pattern in guidelines
- ignore PT011 rule for flake8

## Testing
- `./scripts/check-quality.sh`
- `python scripts/check_test_naming.py`

------
https://chatgpt.com/codex/tasks/task_e_6856482c73448329ad7c4d0a2c9e8669