### PR TITLE
Improve Slack signature validator tests

### DIFF
--- a/tests/unit/infrastructure/security/test_slack_signature_validator.py
+++ b/tests/unit/infrastructure/security/test_slack_signature_validator.py
@@ -25,6 +25,13 @@ class TestSlackSignatureValidator:
         """Slack signature validator with test signing secret."""
         return SlackSignatureValidator(signing_secret=signing_secret)
 
+    @pytest.fixture
+    def relaxed_validator(self, signing_secret):
+        """Validator with extended replay window for deterministic payload tests."""
+        return SlackSignatureValidator(
+            signing_secret=signing_secret, replay_window_seconds=999999999
+        )
+
     def test_validates_authentic_slack_signature(self, validator, signing_secret):
         """Test that valid Slack signatures pass validation."""
         # Arrange
@@ -161,3 +168,61 @@ class TestSlackSignatureValidator:
                 timestamp="invalid_timestamp",
                 signature="v0=some_signature",
             )
+
+    @pytest.fixture
+    def known_valid_payload(self, signing_secret):
+        """Provide a tuple of body, timestamp and signature for deterministic tests."""
+        body = b'{"type":"challenge"}'
+        timestamp = "1609459200"  # 2021-01-01T00:00:00Z
+        sig_basestring = b"v0:" + timestamp.encode() + b":" + body
+        signature = (
+            "v0="
+            + hmac.new(
+                signing_secret.encode("utf-8"), sig_basestring, hashlib.sha256
+            ).hexdigest()
+        )
+        return body, timestamp, signature
+
+    def test_compute_expected_signature_known_value(
+        self, relaxed_validator, known_valid_payload
+    ):
+        """_compute_expected_signature should produce expected HMAC digest."""
+        body, timestamp, signature = known_valid_payload
+        sig_basestring = b"v0:" + timestamp.encode() + b":" + body
+
+        assert (
+            relaxed_validator._compute_expected_signature(sig_basestring) == signature
+        )
+
+    def test_validate_signature_accepts_known_payload(
+        self, relaxed_validator, known_valid_payload
+    ):
+        """Validator should accept a correctly signed request."""
+        body, timestamp, signature = known_valid_payload
+        request = WebhookRequest(body=body, timestamp=timestamp, signature=signature)
+
+        assert relaxed_validator.validate_signature(request) is True
+
+    def test_validate_signature_rejects_tampered_body(
+        self, relaxed_validator, known_valid_payload
+    ):
+        """Validator should reject if the body differs from signature."""
+        body, timestamp, signature = known_valid_payload
+        tampered_body = b'{"type":"changed"}'
+        request = WebhookRequest(
+            body=tampered_body, timestamp=timestamp, signature=signature
+        )
+
+        assert relaxed_validator.validate_signature(request) is False
+
+    def test_validate_signature_rejects_wrong_timestamp(
+        self, relaxed_validator, known_valid_payload
+    ):
+        """Validator should reject if the timestamp differs from signature."""
+        body, _timestamp, signature = known_valid_payload
+        wrong_timestamp = "1609459201"
+        request = WebhookRequest(
+            body=body, timestamp=wrong_timestamp, signature=signature
+        )
+
+        assert relaxed_validator.validate_signature(request) is False


### PR DESCRIPTION
## Summary
- add deterministic fixtures for signature verification
- test validator with known payloads including tampered cases

## Testing
- `pytest --cov=src --cov-fail-under=80 tests/`


------
https://chatgpt.com/codex/tasks/task_e_685677da38048329b2cc53bd4f797d18