### PR TITLE
Add integration tests for SQSJobQueue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "types-boto3>=1.0.0",
     "respx>=0.20.2",
     "flake8-pytest-style>=2.1.0",
-    "moto[sqs,secretsmanager]>=5.0.0",  # v5.0+ required for proper SQS message attributes
+    "moto[sqs,secretsmanager]>=5.1.6",  # v5.0+ required for proper SQS message attributes
 ]
 
 [build-system]
@@ -130,6 +130,9 @@ skips = ["B101", "B104"]  # Skip assert_used test (pytest uses asserts), skip bi
 severity = "medium"
 
 [dependency-groups]
+dev = [
+    "moto[sqs]>=5.1.6",
+]
 webhook = [
     "boto3>=1.37.3",
     "fastapi>=0.115.12",

--- a/tests/integration/jobs/test_sqs_job_queue_integration.py
+++ b/tests/integration/jobs/test_sqs_job_queue_integration.py
@@ -1,0 +1,115 @@
+import asyncio
+import json
+from typing import Tuple
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from emojismith.infrastructure.jobs.sqs_job_queue import SQSJobQueue
+from shared.domain.entities import EmojiGenerationJob
+from shared.domain.value_objects import EmojiSharingPreferences
+
+
+class AsyncClient:
+    """Minimal async wrapper around a boto3 client."""
+
+    def __init__(self, client: boto3.client) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> "AsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    async def send_message(self, **kwargs):
+        return self._client.send_message(**kwargs)
+
+    async def receive_message(self, **kwargs):
+        return self._client.receive_message(**kwargs)
+
+    async def delete_message(self, **kwargs):
+        return self._client.delete_message(**kwargs)
+
+
+class AsyncSession:
+    """Async wrapper that mimics aioboto3 session behavior."""
+
+    def __init__(self, region_name: str) -> None:
+        self._session = boto3.Session(region_name=region_name)
+
+    def client(self, service_name: str):
+        return AsyncClient(self._session.client(service_name))
+
+
+@pytest.fixture
+def sqs_env() -> Tuple[AsyncSession, str]:
+    """Create an in-memory SQS queue and session."""
+    with mock_aws():
+        sqs = boto3.client("sqs", region_name="us-east-1")
+        queue_url = sqs.create_queue(QueueName="emoji-jobs")["QueueUrl"]
+        session = AsyncSession(region_name="us-east-1")
+        yield session, queue_url
+
+
+@pytest.fixture
+def sample_job() -> EmojiGenerationJob:
+    """Return a sample emoji generation job."""
+    return EmojiGenerationJob.create_new(
+        message_text="integration test",
+        user_description="rocket",
+        emoji_name="rocket_emoji",
+        user_id="U1",
+        channel_id="C1",
+        timestamp="1234567890.123",
+        team_id="T1",
+        sharing_preferences=EmojiSharingPreferences.default_for_context(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_enqueue_and_dequeue_job(
+    sqs_env: Tuple[AsyncSession, str], sample_job: EmojiGenerationJob
+) -> None:
+    """Jobs should round trip through SQS without loss."""
+    session, queue_url = sqs_env
+    queue = SQSJobQueue(session=session, queue_url=queue_url)
+
+    job_id = await queue.enqueue_job(sample_job)
+    assert job_id == sample_job.job_id
+
+    result = await queue.dequeue_job()
+    assert result is not None
+    dequeued, handle = result
+    assert dequeued.job_id == sample_job.job_id
+
+    await queue.complete_job(dequeued, handle)
+
+    async with session.client("sqs") as client:
+        messages = await client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=0)
+        assert "Messages" not in messages
+
+
+@pytest.mark.asyncio
+async def test_handles_message_attributes_and_delay(
+    sqs_env: Tuple[AsyncSession, str], sample_job: EmojiGenerationJob
+) -> None:
+    """Queue should eventually return delayed messages with attributes intact."""
+    session, queue_url = sqs_env
+    queue = SQSJobQueue(session=session, queue_url=queue_url)
+
+    async with session.client("sqs") as client:
+        await client.send_message(
+            QueueUrl=queue_url,
+            MessageBody=json.dumps(sample_job.to_dict()),
+            DelaySeconds=1,
+            MessageAttributes={"source": {"DataType": "String", "StringValue": "test"}},
+        )
+
+    await asyncio.sleep(1)
+    result = await queue.dequeue_job()
+    assert result is not None
+    job, handle = result
+    assert job.job_id == sample_job.job_id
+    await queue.complete_job(job, handle)

--- a/uv.lock
+++ b/uv.lock
@@ -478,6 +478,9 @@ dev = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "moto" },
+]
 webhook = [
     { name = "boto3" },
     { name = "fastapi" },
@@ -497,7 +500,7 @@ requires-dist = [
     { name = "flake8-pytest-style", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "mangum", specifier = ">=0.17.0" },
-    { name = "moto", extras = ["sqs", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "moto", extras = ["sqs", "secretsmanager"], marker = "extra == 'dev'", specifier = ">=5.1.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -516,6 +519,7 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
+dev = [{ name = "moto", extras = ["sqs"], specifier = ">=5.1.6" }]
 webhook = [
     { name = "boto3", specifier = ">=1.37.3" },
     { name = "fastapi", specifier = ">=0.115.12" },
@@ -1248,11 +1252,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `moto` dev dependency for AWS mocking
- create async wrapper to use boto3 in tests
- add integration tests covering SQS job queue

## Testing
- `pre-commit run --files tests/integration/jobs/test_sqs_job_queue_integration.py pyproject.toml uv.lock`
- `pytest --cov=src --cov-fail-under=80 tests/`

------
https://chatgpt.com/codex/tasks/task_e_6856780839188329b989f500de513a8b