### PR TITLE
Add integration tests for SQS job queue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ skips = ["B101", "B104"]  # Skip assert_used test (pytest uses asserts), skip bi
 severity = "medium"
 
 [dependency-groups]
+dev = [
+    "moto[sqs]>=5.1.6",
+]
 webhook = [
     "boto3>=1.37.3",
     "fastapi>=0.115.12",

--- a/tests/integration/test_sqs_job_queue_integration.py
+++ b/tests/integration/test_sqs_job_queue_integration.py
@@ -1,0 +1,94 @@
+import asyncio
+import boto3
+import pytest
+from moto import mock_aws
+from emojismith.infrastructure.jobs.sqs_job_queue import SQSJobQueue
+from shared.domain.entities import EmojiGenerationJob
+from shared.domain.value_objects import EmojiSharingPreferences
+
+
+class AsyncClientWrapper:
+    """Async wrapper around boto3 client methods."""
+
+    def __init__(self, client: boto3.client) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> "AsyncClientWrapper":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def create_queue(self, **kwargs):
+        return await asyncio.to_thread(self._client.create_queue, **kwargs)
+
+    async def send_message(self, **kwargs):
+        return await asyncio.to_thread(self._client.send_message, **kwargs)
+
+    async def receive_message(self, **kwargs):
+        return await asyncio.to_thread(self._client.receive_message, **kwargs)
+
+    async def delete_message(self, **kwargs):
+        return await asyncio.to_thread(self._client.delete_message, **kwargs)
+
+
+class AsyncBoto3Session:
+    """Return async client wrappers compatible with SQSJobQueue."""
+
+    def client(self, service_name: str, **kwargs) -> AsyncClientWrapper:
+        client = boto3.client(service_name, region_name="us-east-1", **kwargs)
+        return AsyncClientWrapper(client)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enqueue_and_complete_job_flow() -> None:
+    """Enqueue and dequeue a job using a real SQS backend."""
+    with mock_aws():
+        session = AsyncBoto3Session()
+        async with session.client("sqs") as client:
+            queue_url = (await client.create_queue(QueueName="test-queue"))["QueueUrl"]
+
+        job_queue = SQSJobQueue(session=session, queue_url=queue_url)
+
+        job = EmojiGenerationJob.create_new(
+            message_text="Integration test",
+            user_description="party parrot",
+            emoji_name="party_parrot",
+            user_id="U1",
+            channel_id="C1",
+            timestamp="111",
+            team_id="T1",
+            sharing_preferences=EmojiSharingPreferences.default_for_context(),
+        )
+
+        job_id = await job_queue.enqueue_job(job)
+        assert job_id == job.job_id
+
+        result = await job_queue.dequeue_job()
+        assert result is not None
+        dequeued_job, receipt_handle = result
+        assert dequeued_job.job_id == job.job_id
+
+        await job_queue.complete_job(dequeued_job, receipt_handle)
+
+        async with session.client("sqs") as client:
+            messages = await client.receive_message(QueueUrl=queue_url)
+            assert "Messages" not in messages
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dequeue_empty_queue_returns_none() -> None:
+    """Dequeuing an empty queue should return None."""
+    with mock_aws():
+        session = AsyncBoto3Session()
+        async with session.client("sqs") as client:
+            queue_url = (await client.create_queue(QueueName="test-queue-empty"))[
+                "QueueUrl"
+            ]
+
+        job_queue = SQSJobQueue(session=session, queue_url=queue_url)
+
+        result = await job_queue.dequeue_job()
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -478,6 +478,9 @@ dev = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "moto" },
+]
 webhook = [
     { name = "boto3" },
     { name = "fastapi" },
@@ -516,6 +519,7 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
+dev = [{ name = "moto", extras = ["sqs"], specifier = ">=5.1.6" }]
 webhook = [
     { name = "boto3", specifier = ">=1.37.3" },
     { name = "fastapi", specifier = ">=0.115.12" },
@@ -1248,11 +1252,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add moto to dev dependency group
- create integration tests exercising `SQSJobQueue` against a mocked SQS backend

## Testing
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest --cov=src --cov-fail-under=80 -q`

------
https://chatgpt.com/codex/tasks/task_e_6856780839188329b989f500de513a8b