### PR TITLE
Fix Lambda import error in webhook handler

### DIFF
--- a/src/emojismith/infrastructure/aws/webhook_handler.py
+++ b/src/emojismith/infrastructure/aws/webhook_handler.py
@@ -15,7 +15,12 @@ from webhook.infrastructure.sqs_job_queue import SQSJobQueue
 from webhook.infrastructure.slack_signature_validator import SlackSignatureValidator
 from webhook.security.webhook_security_service import WebhookSecurityService
 
-from .secrets_loader import AWSSecretsLoader
+try:
+    # When deployed as Lambda package, secrets_loader is at root
+    from secrets_loader import AWSSecretsLoader  # type: ignore[import-not-found]
+except ImportError:
+    # When running locally or in tests, use relative import
+    from .secrets_loader import AWSSecretsLoader
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -62,10 +67,70 @@ if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
 
 
 def _create_app() -> Any:
-    from emojismith.presentation.web.slack_webhook_api import create_webhook_api
-    from emojismith.application.create_webhook_app import create_webhook_app
+    """Create minimal FastAPI app for webhook handling."""
+    from fastapi import FastAPI, Request, HTTPException
+    import json
+    import urllib.parse
 
-    return create_webhook_api(create_webhook_app())
+    app = FastAPI(
+        title="Emoji Smith Webhook",
+        description="Minimal webhook handler for Slack events",
+        version="0.1.0",
+    )
+
+    # Create handler and security service
+    webhook_handler, security_service = create_webhook_handler()
+
+    @app.get("/health")
+    async def health_check() -> dict:
+        return {"status": "healthy", "service": "webhook"}
+
+    @app.post("/slack/events")
+    async def slack_events(request: Request) -> dict:
+        body = await request.body()
+        headers = dict(request.headers)
+
+        # Verify Slack signature
+        from webhook.domain.webhook_request import WebhookRequest
+
+        timestamp = headers.get("x-slack-request-timestamp", "")
+        signature = headers.get("x-slack-signature", "")
+
+        webhook_request = WebhookRequest(
+            body=body, timestamp=timestamp, signature=signature
+        )
+
+        if not security_service.is_authentic_webhook(webhook_request):
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+        # Parse payload
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except Exception:
+            # Handle URL-encoded form data
+            form_data = urllib.parse.parse_qs(body.decode("utf-8"))
+            payload_str = form_data.get("payload", ["{}"])[0]
+            payload = json.loads(payload_str)
+
+        # Handle URL verification
+        if payload.get("type") == "url_verification":
+            return {"challenge": payload.get("challenge")}
+
+        # Route to appropriate handler
+        event_type = payload.get("type")
+        if event_type == "message_action":
+            return await webhook_handler.handle_message_action(payload)
+        elif event_type == "view_submission":
+            return await webhook_handler.handle_modal_submission(payload)
+
+        return {"status": "ignored"}
+
+    @app.post("/slack/interactive")
+    async def slack_interactive(request: Request) -> dict:
+        # Same as events endpoint for interactive components
+        return await slack_events(request)
+
+    return app
 
 
 app = _create_app()


### PR DESCRIPTION
## Summary
- Fixes production Lambda error: "Unable to import module 'webhook_handler'"
- Makes webhook handler self-contained to maintain minimal dependencies
- Ensures fast cold starts for Slack's 3-second timeout requirement

## Changes
1. **Fixed secrets_loader import**: Added try-except pattern to handle both Lambda package (direct import) and local development (relative import) environments
2. **Removed emojismith dependencies**: Replaced imports from emojismith modules with inline FastAPI app creation
3. **Fixed security validation**: Updated to use correct `WebhookRequest` object with `is_authentic_webhook` method

## Test Plan
- [ ] Verify webhook package builds successfully with `./scripts/build_webhook_package.sh`
- [ ] Confirm Lambda deploys without import errors
- [ ] Test Slack webhook interactions work correctly
- [ ] Verify cold start performance remains under 3 seconds

## Architecture Compliance
This change adheres to CLAUDE.md's dual Lambda architecture:
- Maintains minimal dependencies for webhook Lambda
- Keeps webhook handler self-contained
- Preserves fast cold start performance

🤖 Generated with [Claude Code](https://claude.ai/code)