### PR TITLE
fix(cdk): remove request_templates from API Gateway Lambda integration

### DIFF
--- a/infra/stacks/emoji_smith_stack.py
+++ b/infra/stacks/emoji_smith_stack.py
@@ -328,7 +328,6 @@ class EmojiSmithStack(Stack):
         # Create Lambda integration
         webhook_integration = apigateway.LambdaIntegration(
             self.webhook_lambda,
-            request_templates={"application/json": '{"statusCode": "200"}'},
         )
 
         # Add health endpoint


### PR DESCRIPTION
## Summary
- Removed `request_templates` parameter from API Gateway Lambda integration that was breaking webhook functionality
- This fixes the Slack modal not opening when clicking "Create Emoji"

## Problem
The `request_templates` configuration was replacing all incoming request bodies with `{"statusCode": "200"}` instead of passing the actual Slack payload to the Lambda function. This caused:
- Pydantic validation errors about missing query parameter 'request'
- Slack modals failing to open
- Webhook handler unable to process any Slack events

## Root Cause
- The problematic configuration has been in the codebase since the initial CDK setup (commit c87ae53)
- It only became an issue after the webhook handler refactoring on June 21 (commit f2ebb64) that made the handler self-contained
- The refactoring changed how the FastAPI app processes requests, making it incompatible with the transformed request body

## Solution
Removed the `request_templates` parameter to allow API Gateway to pass the original request body to Lambda as expected for AWS_PROXY integrations.

## Testing
After deployment:
1. Click "Create Emoji" in Slack
2. Modal should open successfully
3. New logging added in PR #319 will show actual Slack event details

🤖 Generated with [Claude Code](https://claude.ai/code)