### PR TITLE
fix(lambda): correct webhook handler module path

### DIFF
--- a/infra/stacks/emoji_smith_stack.py
+++ b/infra/stacks/emoji_smith_stack.py
@@ -217,7 +217,7 @@ class EmojiSmithStack(Stack):
             self,
             "EmojiSmithWebhook",
             code=_lambda.Code.from_asset(webhook_package_path),
-            handler="webhook_handler.handler",
+            handler="emojismith.infrastructure.aws.webhook_handler.handler",
             runtime=_lambda.Runtime.PYTHON_3_12,
             timeout=Duration.seconds(30),  # Fast webhook processing
             memory_size=512,  # Reduced memory for minimal package

--- a/tests/unit/infrastructure/test_cdk_stack.py
+++ b/tests/unit/infrastructure/test_cdk_stack.py
@@ -1,0 +1,60 @@
+"""Test CDK stack configuration to prevent Lambda handler regressions."""
+
+from unittest.mock import patch
+from aws_cdk import App
+from aws_cdk.assertions import Template, Match
+from infra.stacks.emoji_smith_stack import EmojiSmithStack
+
+
+class TestEmojiSmithStack:
+    """Test suite for CDK stack configuration."""
+
+    def test_webhook_lambda_handler_path_is_correct(self):
+        """Webhook Lambda handler must use correct module path."""
+        # Arrange
+        app = App()
+
+        # Mock the file existence checks to avoid file system dependencies
+        with patch("os.path.exists", return_value=True):
+            # Act
+            stack = EmojiSmithStack(app, "test-stack")
+
+            # Get the CloudFormation template
+            template = Template.from_stack(stack)
+
+            # Assert - verify the handler path in the synthesized template
+            template.has_resource_properties(
+                "AWS::Lambda::Function",
+                {"Handler": "emojismith.infrastructure.aws.webhook_handler.handler"},
+            )
+
+    def test_worker_lambda_uses_correct_cmd(self):
+        """Worker Lambda container must specify correct handler command."""
+        # Arrange
+        app = App()
+        app.node.set_context(
+            "imageUri", "123456789.dkr.ecr.us-east-2.amazonaws.com/emoji-smith:latest"
+        )
+
+        # Mock the file existence for webhook package
+        with patch("os.path.exists", return_value=True):
+            # Act
+            stack = EmojiSmithStack(app, "test-stack")
+
+            # Get the CloudFormation template
+            template = Template.from_stack(stack)
+
+            # Assert - verify the worker Lambda has correct CMD in ImageConfig
+            template.has_resource_properties(
+                "AWS::Lambda::Function",
+                Match.object_like(
+                    {
+                        "PackageType": "Image",
+                        "ImageConfig": {
+                            "Command": [
+                                "emojismith.infrastructure.aws.worker_handler.handler"
+                            ]
+                        },
+                    }
+                ),
+            )


### PR DESCRIPTION
## Summary
- Fixed Lambda import error causing `Runtime.ImportModuleError: Unable to import module 'webhook_handler'`
- Updated webhook handler path to match architecture constraints in CLAUDE.md
- Added CDK stack tests to prevent future handler path regressions

## Problem
The CloudWatch logs showed that the webhook Lambda was failing with an import error:
```
Runtime.ImportModuleError: Unable to import module 'webhook_handler': No module named 'webhook'
```

## Solution
Updated the handler path in the CDK stack from:
- `webhook_handler.handler` 
To:
- `emojismith.infrastructure.aws.webhook_handler.handler`

This matches the immutable Lambda handler locations defined in CLAUDE.md:
```
src/emojismith/infrastructure/aws/webhook_handler.py
src/emojismith/infrastructure/aws/worker_handler.py
```

## Testing
- Added comprehensive CDK stack tests to verify both webhook and worker Lambda configurations
- Tests ensure handler paths match architecture constraints
- All quality checks pass (black, flake8, mypy, bandit, pytest)

🤖 Generated with [Claude Code](https://claude.ai/code)