### PR TITLE
fix(lambda): correct webhook package module structure

### DIFF
--- a/scripts/build_webhook_package.sh
+++ b/scripts/build_webhook_package.sh
@@ -30,11 +30,9 @@ uv pip install -r requirements-webhook.lock --target "$TEMP_DIR" --no-deps
 
 # Copy webhook source code maintaining directory structure
 echo -e "${YELLOW}Copying webhook source code...${NC}"
-# Copy webhook and shared modules (these stay under src/)
-mkdir -p "$TEMP_DIR/src"
-cp -r src/webhook "$TEMP_DIR/src/"
-cp -r src/shared "$TEMP_DIR/src/"
-cp src/__init__.py "$TEMP_DIR/src/"
+# Copy webhook and shared modules to root for correct import paths
+cp -r src/webhook "$TEMP_DIR/"
+cp -r src/shared "$TEMP_DIR/"
 
 # Copy emojismith module to root so Lambda can import it directly
 mkdir -p "$TEMP_DIR/emojismith/infrastructure/aws"


### PR DESCRIPTION
## Summary
- Fixed Lambda import error `No module named 'emojismith'`
- Updated build script to place webhook and shared modules at package root
- Maintains clean architecture separation between webhook and emojismith modules

## Problem
The Lambda was failing with `Runtime.ImportModuleError` because the webhook package structure didn't match the import statements. The build script was placing modules under `src/` but the imports expected them at the root.

## Solution
Modified `scripts/build_webhook_package.sh` to copy modules to the correct locations:
- `webhook/` module → package root (not `src/webhook/`)
- `shared/` module → package root (not `src/shared/`)

This aligns the package structure with the existing import statements while maintaining the architectural separation where the webhook module remains independent of emojismith.

## Test plan
- [x] Run quality checks (`./scripts/check-quality.sh`)
- [x] Build webhook package (`./scripts/build_webhook_package.sh`)
- [x] Verify package structure (`unzip -l webhook_package.zip`)
- [ ] Deploy to Lambda and verify imports work correctly
- [ ] Test webhook endpoint responds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)