### PR TITLE
feat: modern emoji creation modal

### DIFF
--- a/src/emojismith/infrastructure/aws/webhook_handler.py
+++ b/src/emojismith/infrastructure/aws/webhook_handler.py
@@ -139,6 +139,9 @@ def _create_app() -> Any:
         elif event_type == "view_submission":
             logger.info("Handling view submission")
             return await webhook_handler.handle_modal_submission(payload)
+        elif event_type == "block_actions":
+            logger.info("Handling block actions")
+            return await webhook_handler.handle_block_actions(payload)
 
         logger.warning("Unhandled event type: %s", event_type)
         return {"status": "ignored"}

--- a/src/emojismith/infrastructure/slack/slack_api.py
+++ b/src/emojismith/infrastructure/slack/slack_api.py
@@ -20,6 +20,10 @@ class SlackAPIRepository(SlackRepository):
         """Open modal dialog in Slack."""
         await self._client.views_open(trigger_id=trigger_id, view=view)
 
+    async def update_modal(self, view_id: str, view: dict[str, Any]) -> None:
+        """Update an existing modal dialog in Slack."""
+        await self._client.views_update(view_id=view_id, view=view)
+
     async def upload_emoji(self, name: str, image_data: bytes) -> bool:
         """Upload custom emoji to Slack workspace."""
         # TODO: Implement proper image hosting service for production

--- a/src/shared/domain/repositories/slack_repository.py
+++ b/src/shared/domain/repositories/slack_repository.py
@@ -15,6 +15,14 @@ class SlackModalRepository(Protocol):
             view: Modal view definition following Slack Block Kit format
         """
 
+    async def update_modal(self, view_id: str, view: dict[str, Any]) -> None:
+        """Update an existing modal dialog in Slack.
+
+        Args:
+            view_id: ID of the view to update
+            view: Updated modal view definition following Slack Block Kit format
+        """
+
 
 @runtime_checkable
 class SlackEmojiRepository(Protocol):

--- a/src/webhook/domain/slack_payloads.py
+++ b/src/webhook/domain/slack_payloads.py
@@ -222,15 +222,15 @@ class ModalSubmissionPayload:
         form_values = FormValues(
             emoji_name=create_form_block(values_data["emoji_name"]),
             emoji_description=create_form_block(values_data["emoji_description"]),
-            share_location=create_form_block(values_data["share_location"]),
+            share_location=create_form_block(values_data.get("share_location", {})),
             instruction_visibility=create_form_block(
-                values_data["instruction_visibility"]
+                values_data.get("instruction_visibility", {})
             ),
-            image_size=create_form_block(values_data["image_size"]),
+            image_size=create_form_block(values_data.get("image_size", {})),
             style_type=create_form_block(values_data["style_type"]),
-            color_scheme=create_form_block(values_data["color_scheme"]),
+            color_scheme=create_form_block(values_data.get("color_scheme", {})),
             detail_level=create_form_block(values_data["detail_level"]),
-            tone=create_form_block(values_data["tone"]),
+            tone=create_form_block(values_data.get("tone", {})),
         )
 
         view = ModalView(

--- a/src/webhook/handler.py
+++ b/src/webhook/handler.py
@@ -97,43 +97,45 @@ class WebhookHandler:
             if len(emoji_name) > 32:
                 raise ValueError("Emoji name must be 32 characters or less")
 
-            # Extract share location with None check
-            share_select = state["share_location"].share_location_select
-            if share_select is None:
-                raise ValueError("Missing share location")
-            share_location = share_select["selected_option"]["value"]
-
-            # Extract visibility with None check
-            vis_select = state["instruction_visibility"].visibility_select
-            if vis_select is None:
-                raise ValueError("Missing visibility setting")
-            visibility = vis_select["selected_option"]["value"]
-
-            # Extract image size with None check
-            size_select = state["image_size"].size_select
-            if size_select is None:
-                raise ValueError("Missing image size")
-            image_size = size_select["selected_option"]["value"]
-
+            # Extract style preferences from basic fields (always present)
             style_block = state["style_type"].style_select
             if style_block is None:
                 raise ValueError("Missing style type")
             style_type = style_block["selected_option"]["value"]
-
-            color_block = state["color_scheme"].color_select
-            if color_block is None:
-                raise ValueError("Missing color scheme")
-            color_scheme = color_block["selected_option"]["value"]
 
             detail_block = state["detail_level"].detail_select
             if detail_block is None:
                 raise ValueError("Missing detail level")
             detail_level = detail_block["selected_option"]["value"]
 
+            # Extract advanced fields with defaults (may not be present)
+            # Share location
+            share_select = state["share_location"].share_location_select
+            share_location = (
+                share_select["selected_option"]["value"] if share_select else "channel"
+            )
+
+            # Visibility
+            vis_select = state["instruction_visibility"].visibility_select
+            visibility = (
+                vis_select["selected_option"]["value"] if vis_select else "show"
+            )
+
+            # Image size
+            size_select = state["image_size"].size_select
+            image_size = (
+                size_select["selected_option"]["value"] if size_select else "512"
+            )
+
+            # Color scheme
+            color_block = state["color_scheme"].color_select
+            color_scheme = (
+                color_block["selected_option"]["value"] if color_block else "auto"
+            )
+
+            # Tone
             tone_block = state["tone"].tone_select
-            if tone_block is None:
-                raise ValueError("Missing tone")
-            tone = tone_block["selected_option"]["value"]
+            tone = tone_block["selected_option"]["value"] if tone_block else "fun"
 
             metadata = json.loads(modal_payload.view.private_metadata)
         except (KeyError, json.JSONDecodeError, ValueError) as exc:
@@ -185,6 +187,160 @@ class WebhookHandler:
                 },
             }
 
+    def _get_advanced_option_blocks(self) -> list[dict[str, Any]]:
+        """Return the advanced option blocks for the modal."""
+        return [
+            {"type": "divider"},
+            {
+                "type": "input",
+                "block_id": "color_scheme",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "color_select",
+                    "initial_option": {
+                        "text": {"type": "plain_text", "text": "Auto"},
+                        "value": "auto",
+                    },
+                    "options": [
+                        {
+                            "text": {"type": "plain_text", "text": "Auto"},
+                            "value": "auto",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Vibrant"},
+                            "value": "vibrant",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Pastel"},
+                            "value": "pastel",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Monochrome"},
+                            "value": "monochrome",
+                        },
+                    ],
+                },
+                "label": {"type": "plain_text", "text": "Color Scheme"},
+                "optional": True,
+            },
+            {
+                "type": "input",
+                "block_id": "tone",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "tone_select",
+                    "initial_option": {
+                        "text": {"type": "plain_text", "text": "Fun"},
+                        "value": "fun",
+                    },
+                    "options": [
+                        {"text": {"type": "plain_text", "text": "Fun"}, "value": "fun"},
+                        {
+                            "text": {"type": "plain_text", "text": "Professional"},
+                            "value": "professional",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Quirky"},
+                            "value": "quirky",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Serious"},
+                            "value": "serious",
+                        },
+                    ],
+                },
+                "label": {"type": "plain_text", "text": "Tone"},
+                "optional": True,
+            },
+            {
+                "type": "input",
+                "block_id": "share_location",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "share_location_select",
+                    "initial_option": {
+                        "text": {"type": "plain_text", "text": "Current Channel"},
+                        "value": "channel",
+                    },
+                    "options": [
+                        {
+                            "text": {"type": "plain_text", "text": "Current Channel"},
+                            "value": "channel",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Workspace"},
+                            "value": "workspace",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Private"},
+                            "value": "private",
+                        },
+                    ],
+                },
+                "label": {"type": "plain_text", "text": "Share Location"},
+                "optional": True,
+            },
+            {
+                "type": "input",
+                "block_id": "instruction_visibility",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "visibility_select",
+                    "initial_option": {
+                        "text": {"type": "plain_text", "text": "Show Description"},
+                        "value": "show",
+                    },
+                    "options": [
+                        {
+                            "text": {"type": "plain_text", "text": "Show Description"},
+                            "value": "show",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "Hide Description"},
+                            "value": "hide",
+                        },
+                    ],
+                },
+                "label": {"type": "plain_text", "text": "Instruction Visibility"},
+                "optional": True,
+            },
+            {
+                "type": "input",
+                "block_id": "image_size",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "size_select",
+                    "initial_option": {
+                        "text": {"type": "plain_text", "text": "512x512 (Recommended)"},
+                        "value": "512",
+                    },
+                    "options": [
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "512x512 (Recommended)",
+                            },
+                            "value": "512",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "256x256"},
+                            "value": "256",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "128x128"},
+                            "value": "128",
+                        },
+                        {
+                            "text": {"type": "plain_text", "text": "64x64"},
+                            "value": "64",
+                        },
+                    ],
+                },
+                "label": {"type": "plain_text", "text": "Image Size"},
+                "optional": True,
+            },
+        ]
+
     async def _build_modern_modal(self, slack_message: SlackMessage) -> dict[str, Any]:
         """Return the modern modal view definition."""
         metadata = {
@@ -195,130 +351,169 @@ class WebhookHandler:
             "team_id": slack_message.team_id,
         }
 
+        # Start with basic blocks
+        blocks = [
+            {
+                "type": "section",
+                "block_id": "preview_section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f'*Creating emoji for:* "{slack_message.text[:100]}"',
+                },
+                "accessory": {
+                    "type": "image",
+                    "image_url": "https://via.placeholder.com/80x80",
+                    "alt_text": "Emoji preview",
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "input",
+                "block_id": "emoji_name",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "name",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "e.g., coding_wizard",
+                    },
+                },
+                "label": {"type": "plain_text", "text": "Emoji Name"},
+            },
+            {
+                "type": "input",
+                "block_id": "emoji_description",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "description",
+                    "multiline": True,
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "e.g., A retro computer terminal with green text",
+                    },
+                },
+                "label": {"type": "plain_text", "text": "Description"},
+            },
+            {
+                "type": "section",
+                "block_id": "style_header",
+                "text": {"type": "mrkdwn", "text": "*Style Preferences*"},
+            },
+            {
+                "type": "actions",
+                "block_id": "style_type",
+                "elements": [
+                    {
+                        "type": "static_select",
+                        "action_id": "style_select",
+                        "initial_option": {
+                            "text": {"type": "plain_text", "text": "Cartoon"},
+                            "value": "cartoon",
+                        },
+                        "options": [
+                            {
+                                "text": {"type": "plain_text", "text": "Cartoon"},
+                                "value": "cartoon",
+                            },
+                            {
+                                "text": {"type": "plain_text", "text": "Realistic"},
+                                "value": "realistic",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Minimalist",
+                                },
+                                "value": "minimalist",
+                            },
+                            {
+                                "text": {"type": "plain_text", "text": "Pixel Art"},
+                                "value": "pixel",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": "actions",
+                "block_id": "detail_level",
+                "elements": [
+                    {
+                        "type": "static_select",
+                        "action_id": "detail_select",
+                        "initial_option": {
+                            "text": {"type": "plain_text", "text": "Simple"},
+                            "value": "simple",
+                        },
+                        "options": [
+                            {
+                                "text": {"type": "plain_text", "text": "Simple"},
+                                "value": "simple",
+                            },
+                            {
+                                "text": {"type": "plain_text", "text": "Detailed"},
+                                "value": "detailed",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {"type": "divider"},
+            {
+                "type": "actions",
+                "block_id": "toggle_advanced",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "toggle_advanced",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "⚙️ Advanced Options",
+                        },
+                        "value": "show",
+                    }
+                ],
+            },
+        ]
+
         return {
             "type": "modal",
             "callback_id": "emoji_creation_modal",
             "title": {"type": "plain_text", "text": "Create Custom Emoji"},
-            "blocks": [
-                {
-                    "type": "section",
-                    "block_id": "preview_section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f'*Creating emoji for:* "{slack_message.text[:100]}"',
-                    },
-                    "accessory": {
-                        "type": "image",
-                        "image_url": "https://via.placeholder.com/80x80",
-                        "alt_text": "Emoji preview",
-                    },
-                },
-                {"type": "divider"},
-                {
-                    "type": "input",
-                    "block_id": "emoji_name",
-                    "element": {
-                        "type": "plain_text_input",
-                        "action_id": "name",
-                        "placeholder": {
-                            "type": "plain_text",
-                            "text": "e.g., coding_wizard",
-                        },
-                    },
-                    "label": {"type": "plain_text", "text": "Emoji Name"},
-                },
-                {
-                    "type": "input",
-                    "block_id": "emoji_description",
-                    "element": {
-                        "type": "plain_text_input",
-                        "action_id": "description",
-                        "multiline": True,
-                        "placeholder": {
-                            "type": "plain_text",
-                            "text": "e.g., A retro computer terminal with green text",
-                        },
-                    },
-                    "label": {"type": "plain_text", "text": "Description"},
-                },
-                {
-                    "type": "section",
-                    "block_id": "style_header",
-                    "text": {"type": "mrkdwn", "text": "*Style Preferences*"},
-                },
-                {
-                    "type": "actions",
-                    "block_id": "style_selections",
-                    "elements": [
-                        {
-                            "type": "static_select",
-                            "action_id": "style_select",
-                            "initial_option": {
-                                "text": {"type": "plain_text", "text": "Cartoon"},
-                                "value": "cartoon",
-                            },
-                            "options": [
-                                {
-                                    "text": {"type": "plain_text", "text": "Cartoon"},
-                                    "value": "cartoon",
-                                },
-                                {
-                                    "text": {"type": "plain_text", "text": "Realistic"},
-                                    "value": "realistic",
-                                },
-                                {
-                                    "text": {
-                                        "type": "plain_text",
-                                        "text": "Minimalist",
-                                    },
-                                    "value": "minimalist",
-                                },
-                                {
-                                    "text": {"type": "plain_text", "text": "Pixel Art"},
-                                    "value": "pixel",
-                                },
-                            ],
-                        },
-                        {
-                            "type": "static_select",
-                            "action_id": "detail_select",
-                            "initial_option": {
-                                "text": {"type": "plain_text", "text": "Simple"},
-                                "value": "simple",
-                            },
-                            "options": [
-                                {
-                                    "text": {"type": "plain_text", "text": "Simple"},
-                                    "value": "simple",
-                                },
-                                {
-                                    "text": {"type": "plain_text", "text": "Detailed"},
-                                    "value": "detailed",
-                                },
-                            ],
-                        },
-                    ],
-                },
-                {"type": "divider"},
-                {
-                    "type": "actions",
-                    "block_id": "toggle_advanced",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "action_id": "toggle_advanced",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "⚙️ Advanced Options",
-                            },
-                            "value": "show",
-                        }
-                    ],
-                },
-            ],
+            "blocks": blocks,
             "submit": {"type": "plain_text", "text": "Generate Emoji"},
             "private_metadata": json.dumps(metadata),
         }
+
+    async def _build_modern_modal_with_advanced(
+        self, slack_message: SlackMessage, show_advanced: bool = False
+    ) -> dict[str, Any]:
+        """Build modal with optional advanced fields."""
+        # Get base modal
+        modal = await self._build_modern_modal(slack_message)
+
+        if show_advanced:
+            # Find the toggle button index
+            toggle_index = -1
+            for i, block in enumerate(modal["blocks"]):
+                if block.get("block_id") == "toggle_advanced":
+                    toggle_index = i
+                    break
+
+            if toggle_index >= 0:
+                # Insert advanced blocks before the toggle button
+                advanced_blocks = self._get_advanced_option_blocks()
+                modal["blocks"][toggle_index:toggle_index] = advanced_blocks
+
+                # Update button text and value
+                modal["blocks"][toggle_index + len(advanced_blocks)]["elements"][0][
+                    "text"
+                ]["text"] = "⚙️ Hide Advanced Options"
+                modal["blocks"][toggle_index + len(advanced_blocks)]["elements"][0][
+                    "value"
+                ] = "hide"
+
+        return modal
 
     async def _open_emoji_creation_modal(
         self, slack_message: SlackMessage, trigger_id: str
@@ -330,3 +525,41 @@ class WebhookHandler:
             "Opening emoji creation modal", extra={"trigger_id": trigger_id}
         )
         await self._slack_repo.open_modal(trigger_id=trigger_id, view=modal_view)
+
+    async def handle_block_actions(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Handle interactive block actions (button clicks, select menus, etc.)."""
+        # For toggle advanced options button
+        actions = payload.get("actions", [])
+
+        for action in actions:
+            if action.get("action_id") == "toggle_advanced":
+                # Get current view
+                view = payload.get("view", {})
+                current_value = action.get("value", "show")
+
+                # Parse metadata to rebuild modal
+                try:
+                    metadata = json.loads(view.get("private_metadata", "{}"))
+                    slack_message = SlackMessage(
+                        text=metadata["message_text"],
+                        user_id=metadata["user_id"],
+                        channel_id=metadata["channel_id"],
+                        timestamp=metadata["timestamp"],
+                        team_id=metadata["team_id"],
+                    )
+
+                    # Build modal with toggled state
+                    show_advanced = current_value == "show"
+                    new_modal = await self._build_modern_modal_with_advanced(
+                        slack_message, show_advanced=show_advanced
+                    )
+
+                    # Update the modal
+                    await self._slack_repo.update_modal(
+                        view_id=view.get("id", ""), view=new_modal
+                    )
+                except Exception:
+                    self._logger.exception("Failed to handle toggle action")
+
+        # Acknowledge the action
+        return {}

--- a/src/webhook/infrastructure/slack_api.py
+++ b/src/webhook/infrastructure/slack_api.py
@@ -19,3 +19,8 @@ class SlackAPIRepository(SlackModalRepository):
         """Open a modal dialog in Slack."""
         self._logger.info(f"Opening modal with trigger_id: {trigger_id}")
         await self._client.views_open(trigger_id=trigger_id, view=view)
+
+    async def update_modal(self, view_id: str, view: dict[str, Any]) -> None:
+        """Update an existing modal dialog in Slack."""
+        self._logger.info(f"Updating modal with view_id: {view_id}")
+        await self._client.views_update(view_id=view_id, view=view)

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -50,10 +50,9 @@ class TestWebhookHandler:
         mock_slack_repo.open_modal.assert_called_once()
         view = mock_slack_repo.open_modal.call_args.kwargs["view"]
         block_ids = [b.get("block_id") for b in view["blocks"]]
-        assert "style_type" in block_ids
-        assert "color_scheme" in block_ids
-        assert "detail_level" in block_ids
-        assert "tone" in block_ids
+        assert "preview_section" in block_ids
+        assert "style_selections" in block_ids
+        assert "toggle_advanced" in block_ids
 
     async def test_message_action_accepts_extra_team_fields(
         self, webhook_handler, mock_slack_repo

--- a/tests/unit/webhook/test_webhook_handler.py
+++ b/tests/unit/webhook/test_webhook_handler.py
@@ -51,7 +51,8 @@ class TestWebhookHandler:
         view = mock_slack_repo.open_modal.call_args.kwargs["view"]
         block_ids = [b.get("block_id") for b in view["blocks"]]
         assert "preview_section" in block_ids
-        assert "style_selections" in block_ids
+        assert "style_type" in block_ids
+        assert "detail_level" in block_ids
         assert "toggle_advanced" in block_ids
 
     async def test_message_action_accepts_extra_team_fields(
@@ -192,3 +193,100 @@ class TestWebhookHandler:
 
         assert result == {"status": "ok"}
         mock_slack_repo.open_modal.assert_called_once()
+
+    async def test_handles_block_actions_toggle_advanced(
+        self, webhook_handler, mock_slack_repo
+    ):
+        """Test toggle advanced options button updates modal."""
+        # Arrange
+        payload = {
+            "type": "block_actions",
+            "actions": [
+                {
+                    "action_id": "toggle_advanced",
+                    "value": "show",
+                }
+            ],
+            "view": {
+                "id": "V123456",
+                "private_metadata": (
+                    '{"message_text": "test emoji", "user_id": "U123", '
+                    '"channel_id": "C123", "timestamp": "123.456", '
+                    '"team_id": "T123"}'
+                ),
+            },
+        }
+
+        # Act
+        result = await webhook_handler.handle_block_actions(payload)
+
+        # Assert
+        assert result == {}
+        mock_slack_repo.update_modal.assert_called_once()
+        view = mock_slack_repo.update_modal.call_args.kwargs["view"]
+
+        # Check that advanced blocks are present
+        block_ids = [b.get("block_id") for b in view["blocks"]]
+        assert "color_scheme" in block_ids
+        assert "tone" in block_ids
+        assert "share_location" in block_ids
+        assert "instruction_visibility" in block_ids
+        assert "image_size" in block_ids
+
+        # Check toggle button changed to "Hide"
+        toggle_block = next(
+            b for b in view["blocks"] if b.get("block_id") == "toggle_advanced"
+        )
+        assert "Hide Advanced Options" in toggle_block["elements"][0]["text"]["text"]
+        assert toggle_block["elements"][0]["value"] == "hide"
+
+    async def test_modal_submission_with_optional_advanced_fields(
+        self, webhook_handler, mock_job_queue
+    ):
+        """Test modal submission works without advanced fields (using defaults)."""
+        # Arrange - minimal payload without advanced fields
+        modal_payload = {
+            "type": "view_submission",
+            "view": {
+                "callback_id": "emoji_creation_modal",
+                "state": {
+                    "values": {
+                        "emoji_name": {"name": {"value": "thumbsup"}},
+                        "emoji_description": {
+                            "description": {"value": "thumbs up gesture"}
+                        },
+                        "style_type": {
+                            "style_select": {"selected_option": {"value": "cartoon"}}
+                        },
+                        "detail_level": {
+                            "detail_select": {"selected_option": {"value": "simple"}}
+                        },
+                        # Advanced fields not present - should use defaults
+                    }
+                },
+                "private_metadata": (
+                    '{"message_text": "great job!", "user_id": "U456", '
+                    '"channel_id": "C456", "timestamp": "456.789", '
+                    '"team_id": "T456"}'
+                ),
+            },
+        }
+
+        # Act
+        result = await webhook_handler.handle_modal_submission(modal_payload)
+
+        # Assert
+        assert result == {"response_action": "clear"}
+        mock_job_queue.enqueue_job.assert_called_once()
+
+        # Verify defaults were used
+        job = mock_job_queue.enqueue_job.call_args[0][0]
+        assert job.sharing_preferences.share_location.value == "channel"  # default
+        assert (
+            job.sharing_preferences.instruction_visibility.value == "EVERYONE"
+        )  # default show -> EVERYONE
+        assert (
+            job.sharing_preferences.image_size.value == "EMOJI_SIZE"
+        )  # default 512 -> EMOJI_SIZE
+        assert job.style_preferences.color_scheme.value == "auto"  # default
+        assert job.style_preferences.tone.value == "fun"  # default


### PR DESCRIPTION
## Summary
Fixes #341

Introduces new mobile‑friendly emoji creation modal with preview section and collapsed advanced options. Tests updated for new block layout.

## Changes
- add `_build_modern_modal` helper in `WebhookHandler`
- update modal blocks with preview, style grid and toggle
- adjust unit test expectations

## Test plan
- [x] `./scripts/check-quality.sh`


------
https://chatgpt.com/codex/tasks/task_e_6867b56f78e08329b02605335215dfdb