### PR TITLE
feat: use gpt-image-1 for emoji generation

### DIFF
--- a/src/emojismith/infrastructure/CLAUDE.md
+++ b/src/emojismith/infrastructure/CLAUDE.md
@@ -136,7 +136,7 @@ class OpenAIService:
         """Generate image and return URL."""
         try:
             response = await self._client.images.generate(
-                model="dall-e-3",
+                model="gpt-image-1",
                 prompt=prompt,
                 size=size,
                 quality=quality,

--- a/src/emojismith/infrastructure/openai/openai_api.py
+++ b/src/emojismith/infrastructure/openai/openai_api.py
@@ -57,57 +57,19 @@ class OpenAIAPIRepository(OpenAIRepository):
     async def enhance_prompt(self, context: str, description: str) -> str:
         await self._ensure_model()
 
-        system_prompt = """You are an expert at creating prompts for DALL-E image
-generation specifically optimized for Slack emoji.
-
-CRITICAL REQUIREMENTS:
-- ALWAYS specify "transparent background" in every prompt
-- Optimize for 128x128 pixel display size
-- Focus on instant recognition at small sizes
-- Use bold, clear shapes with high contrast
-
-SLACK EMOJI TECHNICAL CONSTRAINTS:
-- Display size: 128x128 pixels (though uploaded at higher resolution)
-- Must work well as reactions (tiny 20x20 display)
-- Transparent backgrounds are ESSENTIAL
-- Maximum file size: 128KB
-- Supported formats: PNG, JPG, GIF
-
-PROMPT STRUCTURE TEMPLATE:
-"[Style] [Subject] with [Key Features], transparent background,
-optimized for 128x128 pixel Slack emoji, [Additional Details]"
-
-STYLE OPTIONS (choose most appropriate):
-- Cartoon/illustrated style - Best for fun, approachable emojis
-- Minimalist flat design - Best for professional contexts
-- Pixel art style - Best for retro/gaming themes
-- Realistic style - Best for specific objects/foods
-
-ENHANCEMENT RULES:
-1. Simplify complex descriptions for clarity at small sizes
-2. Emphasize distinctive features that remain visible when tiny
-3. Use vibrant, contrasting colors for visibility
-4. Avoid intricate details that disappear at 128x128
-5. Include relevant context from the message when meaningful
-
-EXAMPLES:
-Input: Context: "Just shipped new feature", Description: "rocket"
-Output: "Cartoon style rocket ship launching with bright orange flames
-and smoke clouds, transparent background, optimized for 128x128 pixel
-Slack emoji, bold outlines, vibrant colors"
-
-Input: Context: "Team celebration", Description: "party"
-Output: "Festive party popper with colorful confetti burst, transparent
-background, optimized for 128x128 pixel Slack emoji, cartoon style with
-bold colors and thick outlines"
-
-Input: Context: "Coffee break", Description: "tired"
-Output: "Sleepy face with coffee cup, half-closed eyes and steam swirls,
-transparent background, optimized for 128x128 pixel Slack emoji, simple
-cartoon style with clear expressions"
-
-Remember: The emoji must be instantly recognizable at 20x20 pixels
-while looking great at 128x128!"""
+        system_prompt = (
+            "You are an expert prompt engineer for the gpt-image-1 model "
+            "that produces Slack emoji.\n\n"
+            "Instructions:\n"
+            "- Always request a transparent background.\n"
+            "- Optimize for 128x128 pixels and ensure recognizability at 20x20.\n"
+            "- Use bold, high-contrast shapes with minimal detail.\n"
+            "- Return only the final prompt text.\n"
+            "- User context and description are provided in triple backticks.\n\n"
+            "Prompt template:\n"
+            '"[Style] [Subject] with [Key Features], transparent background, '
+            'optimized for 128x128 pixel Slack emoji, [Additional Details]"'
+        )
 
         try:
             response = await self._client.chat.completions.create(
@@ -116,7 +78,13 @@ while looking great at 128x128!"""
                     {"role": "system", "content": system_prompt},
                     {
                         "role": "user",
-                        "content": f"Context: {context}\nDescription: {description}",
+                        "content": (
+                            "Context:\n```"
+                            + context
+                            + "```\nDescription:\n```"
+                            + description
+                            + "```"
+                        ),
                     },
                 ],
             )
@@ -127,11 +95,11 @@ while looking great at 128x128!"""
         return response.choices[0].message.content
 
     async def generate_image(self, prompt: str) -> bytes:
-        """Generate an image using DALL-E 3 with fallback to DALL-E 2."""
-        # Try DALL-E 3 first
+        """Generate an image using gpt-image-1 with fallback to DALL-E 2."""
+        # Try gpt-image-1 first
         try:
             response = await self._client.images.generate(
-                model="dall-e-3",
+                model="gpt-image-1",
                 prompt=prompt,
                 n=1,
                 size="1024x1024",
@@ -143,7 +111,9 @@ while looking great at 128x128!"""
         ) as exc:  # pragma: no cover - network error simulated
             raise RateLimitExceededError(str(exc)) from exc
         except Exception as exc:
-            self._logger.warning("DALL-E 3 failed, falling back to DALL-E 2: %s", exc)
+            self._logger.warning(
+                "gpt-image-1 failed, falling back to DALL-E 2: %s", exc
+            )
             # Fallback to DALL-E 2
             try:
                 response = await self._client.images.generate(
@@ -159,7 +129,7 @@ while looking great at 128x128!"""
                 raise RateLimitExceededError(str(rate_exc)) from rate_exc
             except Exception as fallback_exc:
                 self._logger.error(
-                    "Both DALL-E 3 and DALL-E 2 failed: %s", fallback_exc
+                    "Both gpt-image-1 and DALL-E 2 failed: %s", fallback_exc
                 )
                 raise fallback_exc
 

--- a/tests/integration/openai/test_openai_api.py
+++ b/tests/integration/openai/test_openai_api.py
@@ -26,7 +26,7 @@ async def test_enhances_prompt_with_ai_assistance() -> None:
 @pytest.mark.asyncio()
 @pytest.mark.integration()
 async def test_enhance_prompt_uses_comprehensive_system_prompt() -> None:
-    """Test that enhance_prompt uses a comprehensive system prompt for DALL-E."""
+    """Test that enhance_prompt uses a comprehensive system prompt for gpt-image."""
     client = AsyncMock()
     client.chat.completions.create.return_value = AsyncMock(
         choices=[AsyncMock(message=AsyncMock(content="enhanced prompt"))]
@@ -47,12 +47,12 @@ async def test_enhance_prompt_uses_comprehensive_system_prompt() -> None:
     messages = call_args.kwargs["messages"]
     system_prompt = messages[0]["content"]
 
-    # Verify the system prompt contains key requirements for DALL-E emoji generation
+    # Verify the system prompt contains key requirements for gpt-image emoji generation
     assert "transparent background" in system_prompt.lower()
     assert "128x128" in system_prompt
     assert "slack" in system_prompt.lower()
     assert "emoji" in system_prompt.lower()
-    assert "dall-e" in system_prompt.lower() or "dalle" in system_prompt.lower()
+    assert "gpt-image" in system_prompt.lower()
     assert (
         len(system_prompt) > 100
     )  # Should be comprehensive, not just "Enhance emoji prompt"
@@ -124,13 +124,13 @@ async def test_rejects_image_generation_when_b64_json_is_none() -> None:
 
 @pytest.mark.asyncio()
 @pytest.mark.integration()
-async def test_falls_back_to_dalle2_when_dalle3_fails() -> None:
-    """Test that image generation falls back to DALL-E 2 when DALL-E 3 fails."""
+async def test_falls_back_to_dalle2_when_gpt_image_fails() -> None:
+    """Test that image generation falls back to DALL-E 2 when gpt-image-1 fails."""
     client = AsyncMock()
 
-    # First call (DALL-E 3) fails
+    # First call (gpt-image-1) fails
     client.images.generate.side_effect = [
-        Exception("DALL-E 3 not available"),
+        Exception("gpt-image-1 not available"),
         AsyncMock(data=[AsyncMock(b64_json="aGVsbG8=")]),  # DALL-E 2 succeeds
     ]
 
@@ -140,9 +140,9 @@ async def test_falls_back_to_dalle2_when_dalle3_fails() -> None:
     # Should have called both models
     assert client.images.generate.call_count == 2
 
-    # First call should be DALL-E 3
+    # First call should be gpt-image-1
     first_call = client.images.generate.call_args_list[0]
-    assert first_call.kwargs["model"] == "dall-e-3"
+    assert first_call.kwargs["model"] == "gpt-image-1"
 
     # Second call should be DALL-E 2
     second_call = client.images.generate.call_args_list[1]

--- a/tests/integration/openai/test_openai_api_http.py
+++ b/tests/integration/openai/test_openai_api_http.py
@@ -41,7 +41,7 @@ async def test_generate_image_fallback() -> None:
             return httpx.Response(200, json={})
         model = json.loads(request.content)["model"]
         calls.append(model)
-        if model == "dall-e-3":
+        if model == "gpt-image-1":
             return httpx.Response(500)
         b64 = base64.b64encode(b"img").decode()
         return httpx.Response(200, json={"data": [{"b64_json": b64}]})
@@ -56,7 +56,7 @@ async def test_generate_image_fallback() -> None:
     repo = OpenAIAPIRepository(client)
     result = await repo.generate_image("prompt")
     assert result == b"img"
-    assert calls[0] == "dall-e-3"
+    assert calls[0] == "gpt-image-1"
     assert calls[-1] == "dall-e-2"
 
 


### PR DESCRIPTION
## Summary
- switch image generation to `gpt-image-1` with DALL-E 2 fallback
- apply prompt-engineering guidelines for clearer GPT-Image prompts
- update tests and infrastructure docs for new model

## Testing
- `ruff check src/emojismith/infrastructure/openai/openai_api.py tests/integration/openai/test_openai_api.py tests/integration/openai/test_openai_api_http.py`
- `mypy src/emojismith/infrastructure/openai/openai_api.py`
- `pytest tests/integration/openai/test_openai_api.py tests/integration/openai/test_openai_api_http.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6895e4a60428832bbe7cc03fbcd4ce96