### PR TITLE
feat: migrate image generation to gpt-image-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **AI-powered custom emoji generator for Slack workspaces**
 
-Emoji Smith is a Slack bot that automatically generates custom emojis using OpenAI's DALL-E, triggered by message actions. Simply right-click any Slack message, choose "Create Reaction," describe the emoji you want, and watch as AI creates the perfect custom emoji reaction.
+Emoji Smith is a Slack bot that automatically generates custom emojis using OpenAI's gpt-image-1 model, triggered by message actions. Simply right-click any Slack message, choose "Create Reaction," describe the emoji you want, and watch as AI creates the perfect custom emoji reaction.
 
 ## ✨ Features
 
@@ -29,7 +29,7 @@ graph TB
     end
     
     subgraph "AI Generation"
-        E -->|Generate| F[OpenAI DALL-E]
+        E -->|Generate| F[OpenAI gpt-image-1]
         F -->|Upload & React| A
     end
 ```
@@ -38,7 +38,7 @@ For detailed architecture documentation, see [Dual Lambda Architecture](./docs/a
 
 **Tech Stack:**
 - **Backend**: Python 3.12 + FastAPI + Slack Bolt
-- **AI Services**: OpenAI o3 with fallback to gpt-4/gpt-3.5 (prompt enhancement) + DALL-E (image generation)
+- **AI Services**: OpenAI o3 with fallback to gpt-4/gpt-3.5 (prompt enhancement) + gpt-image-1 (image generation)
 - **Infrastructure**: AWS Lambda + API Gateway + SQS + Secrets Manager
 - **Deployment**: AWS CDK + GitHub Actions
 - **Monitoring**: CloudWatch logs + health check endpoint (`/health`)
@@ -135,7 +135,7 @@ aws secretsmanager create-secret --name "emoji-smith/production" --secret-string
 |----------|-------------|---------|---------|
 | `SLACK_BOT_TOKEN` | Slack bot user OAuth token | Required | `xoxb-...` |
 | `SLACK_SIGNING_SECRET` | Slack app signing secret | Required | `...` |
-| `OPENAI_API_KEY` | OpenAI API key for DALL-E | Required | `sk-...` |
+| `OPENAI_API_KEY` | OpenAI API key for gpt-image-1 | Required | `sk-...` |
 | `OPENAI_CHAT_MODEL` | Chat model for prompt enhancement | `o3` | `o3`, `gpt-4`, `gpt-3.5-turbo` |
 | `EMOJISMITH_FORCE_ENTERPRISE` | Force Enterprise Grid mode | `false` | `true`, `false` |
 | `SQS_QUEUE_URL` | AWS SQS queue URL (production) | None | AWS SQS URL |
@@ -324,4 +324,4 @@ MIT License - see [LICENSE](./LICENSE) for details.
 
 ---
 
-**Made with ❤️ and AI** • Powered by OpenAI DALL-E • Deployed on AWS Lambda
+**Made with ❤️ and AI** • Powered by OpenAI gpt-image-1 • Deployed on AWS Lambda

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -143,7 +143,7 @@ pre-commit run mypy --all-files -v
    ```python
    start = time.time()
    response = await openai_client.images.generate(...)
-   logger.info(f"DALL-E took {time.time() - start}s")
+   logger.info(f"gpt-image-1 took {time.time() - start}s")
    ```
 
 3. **Optimize prompt generation**

--- a/src/emojismith/application/use_cases/build_prompt_use_case.py
+++ b/src/emojismith/application/use_cases/build_prompt_use_case.py
@@ -50,7 +50,7 @@ class BuildPromptUseCase:
             style_override: Optional style to override the specification's style
 
         Returns:
-            An optimized prompt string ready for DALL-E
+            An optimized prompt string ready for gpt-image-1
         """
         # If style override is provided, create a new spec with that style
         if style_override:

--- a/src/emojismith/domain/repositories/openai_repository.py
+++ b/src/emojismith/domain/repositories/openai_repository.py
@@ -11,5 +11,5 @@ class OpenAIRepository(Protocol):
         ...
 
     async def generate_image(self, prompt: str) -> bytes:
-        """Generate an emoji image using DALL-E."""
+        """Generate an emoji image using gpt-image-1."""
         ...

--- a/src/emojismith/domain/services/generation_service.py
+++ b/src/emojismith/domain/services/generation_service.py
@@ -26,7 +26,7 @@ class EmojiGenerationService:
         """Generate emoji from a ready-to-use prompt.
 
         Args:
-            prompt: The optimized and enhanced prompt for DALL-E
+            prompt: The optimized and enhanced prompt for gpt-image-1
             name: The name for the generated emoji
 
         Returns:

--- a/src/emojismith/domain/services/prompt_builder_service.py
+++ b/src/emojismith/domain/services/prompt_builder_service.py
@@ -47,7 +47,7 @@ class PromptBuilderService:
             spec: The emoji specification containing description, context, and style
 
         Returns:
-            An optimized prompt string ready for DALL-E
+            An optimized prompt string ready for gpt-image-1
         """
         if not spec or not spec.description:
             raise ValueError("Specification must have a description")

--- a/src/emojismith/infrastructure/CLAUDE.md
+++ b/src/emojismith/infrastructure/CLAUDE.md
@@ -136,7 +136,7 @@ class OpenAIService:
         """Generate image and return URL."""
         try:
             response = await self._client.images.generate(
-                model="dall-e-3",
+                model="gpt-image-1",
                 prompt=prompt,
                 size=size,
                 quality=quality,

--- a/src/emojismith/infrastructure/openai/openai_api.py
+++ b/src/emojismith/infrastructure/openai/openai_api.py
@@ -57,57 +57,21 @@ class OpenAIAPIRepository(OpenAIRepository):
     async def enhance_prompt(self, context: str, description: str) -> str:
         await self._ensure_model()
 
-        system_prompt = """You are an expert at creating prompts for DALL-E image
-generation specifically optimized for Slack emoji.
-
-CRITICAL REQUIREMENTS:
-- ALWAYS specify "transparent background" in every prompt
-- Optimize for 128x128 pixel display size
-- Focus on instant recognition at small sizes
-- Use bold, clear shapes with high contrast
-
-SLACK EMOJI TECHNICAL CONSTRAINTS:
-- Display size: 128x128 pixels (though uploaded at higher resolution)
-- Must work well as reactions (tiny 20x20 display)
-- Transparent backgrounds are ESSENTIAL
-- Maximum file size: 128KB
-- Supported formats: PNG, JPG, GIF
-
-PROMPT STRUCTURE TEMPLATE:
-"[Style] [Subject] with [Key Features], transparent background,
-optimized for 128x128 pixel Slack emoji, [Additional Details]"
-
-STYLE OPTIONS (choose most appropriate):
-- Cartoon/illustrated style - Best for fun, approachable emojis
-- Minimalist flat design - Best for professional contexts
-- Pixel art style - Best for retro/gaming themes
-- Realistic style - Best for specific objects/foods
-
-ENHANCEMENT RULES:
-1. Simplify complex descriptions for clarity at small sizes
-2. Emphasize distinctive features that remain visible when tiny
-3. Use vibrant, contrasting colors for visibility
-4. Avoid intricate details that disappear at 128x128
-5. Include relevant context from the message when meaningful
-
-EXAMPLES:
-Input: Context: "Just shipped new feature", Description: "rocket"
-Output: "Cartoon style rocket ship launching with bright orange flames
-and smoke clouds, transparent background, optimized for 128x128 pixel
-Slack emoji, bold outlines, vibrant colors"
-
-Input: Context: "Team celebration", Description: "party"
-Output: "Festive party popper with colorful confetti burst, transparent
-background, optimized for 128x128 pixel Slack emoji, cartoon style with
-bold colors and thick outlines"
-
-Input: Context: "Coffee break", Description: "tired"
-Output: "Sleepy face with coffee cup, half-closed eyes and steam swirls,
-transparent background, optimized for 128x128 pixel Slack emoji, simple
-cartoon style with clear expressions"
-
-Remember: The emoji must be instantly recognizable at 20x20 pixels
-while looking great at 128x128!"""
+        system_prompt = (
+            "You are an expert prompt engineer for OpenAI's gpt-image-1 model.\n"
+            "Goal: craft vivid prompts for Slack emoji images.\n\n"
+            "Rules:\n"
+            "- Always specify 'transparent background'.\n"
+            "- Optimize for 128x128 display and clarity at 20x20.\n"
+            "- Use bold shapes with high contrast.\n"
+            "- Include relevant context from the message.\n"
+            "- Avoid unnecessary detail; focus on key features.\n\n"
+            "Format:\n"
+            "[Style] depiction of [Subject] with [Key Features], "
+            "transparent background, optimized for 128x128 pixel "
+            "Slack emoji, [Additional Details]\n\n"
+            "Return only the prompt text."
+        )
 
         try:
             response = await self._client.chat.completions.create(
@@ -127,11 +91,11 @@ while looking great at 128x128!"""
         return response.choices[0].message.content
 
     async def generate_image(self, prompt: str) -> bytes:
-        """Generate an image using DALL-E 3 with fallback to DALL-E 2."""
-        # Try DALL-E 3 first
+        """Generate an image using gpt-image-1 with fallback to DALL-E 2."""
+        # Try gpt-image-1 first
         try:
             response = await self._client.images.generate(
-                model="dall-e-3",
+                model="gpt-image-1",
                 prompt=prompt,
                 n=1,
                 size="1024x1024",
@@ -143,7 +107,9 @@ while looking great at 128x128!"""
         ) as exc:  # pragma: no cover - network error simulated
             raise RateLimitExceededError(str(exc)) from exc
         except Exception as exc:
-            self._logger.warning("DALL-E 3 failed, falling back to DALL-E 2: %s", exc)
+            self._logger.warning(
+                "gpt-image-1 failed, falling back to DALL-E 2: %s", exc
+            )
             # Fallback to DALL-E 2
             try:
                 response = await self._client.images.generate(
@@ -159,7 +125,7 @@ while looking great at 128x128!"""
                 raise RateLimitExceededError(str(rate_exc)) from rate_exc
             except Exception as fallback_exc:
                 self._logger.error(
-                    "Both DALL-E 3 and DALL-E 2 failed: %s", fallback_exc
+                    "Both gpt-image-1 and DALL-E 2 failed: %s", fallback_exc
                 )
                 raise fallback_exc
 

--- a/tests/integration/openai/test_openai_api.py
+++ b/tests/integration/openai/test_openai_api.py
@@ -26,7 +26,7 @@ async def test_enhances_prompt_with_ai_assistance() -> None:
 @pytest.mark.asyncio()
 @pytest.mark.integration()
 async def test_enhance_prompt_uses_comprehensive_system_prompt() -> None:
-    """Test that enhance_prompt uses a comprehensive system prompt for DALL-E."""
+    """Test that enhance_prompt uses a comprehensive system prompt for gpt-image-1."""
     client = AsyncMock()
     client.chat.completions.create.return_value = AsyncMock(
         choices=[AsyncMock(message=AsyncMock(content="enhanced prompt"))]
@@ -47,12 +47,13 @@ async def test_enhance_prompt_uses_comprehensive_system_prompt() -> None:
     messages = call_args.kwargs["messages"]
     system_prompt = messages[0]["content"]
 
-    # Verify the system prompt contains key requirements for DALL-E emoji generation
+    # Verify system prompt contains key requirements
+    # for gpt-image-1 emoji generation
     assert "transparent background" in system_prompt.lower()
     assert "128x128" in system_prompt
     assert "slack" in system_prompt.lower()
     assert "emoji" in system_prompt.lower()
-    assert "dall-e" in system_prompt.lower() or "dalle" in system_prompt.lower()
+    assert "gpt-image-1" in system_prompt.lower()
     assert (
         len(system_prompt) > 100
     )  # Should be comprehensive, not just "Enhance emoji prompt"
@@ -124,13 +125,13 @@ async def test_rejects_image_generation_when_b64_json_is_none() -> None:
 
 @pytest.mark.asyncio()
 @pytest.mark.integration()
-async def test_falls_back_to_dalle2_when_dalle3_fails() -> None:
-    """Test that image generation falls back to DALL-E 2 when DALL-E 3 fails."""
+async def test_falls_back_to_dalle2_when_gpt_image_1_fails() -> None:
+    """Test that image generation falls back to DALL-E 2 when gpt-image-1 fails."""
     client = AsyncMock()
 
-    # First call (DALL-E 3) fails
+    # First call (gpt-image-1) fails
     client.images.generate.side_effect = [
-        Exception("DALL-E 3 not available"),
+        Exception("gpt-image-1 not available"),
         AsyncMock(data=[AsyncMock(b64_json="aGVsbG8=")]),  # DALL-E 2 succeeds
     ]
 
@@ -140,9 +141,9 @@ async def test_falls_back_to_dalle2_when_dalle3_fails() -> None:
     # Should have called both models
     assert client.images.generate.call_count == 2
 
-    # First call should be DALL-E 3
+    # First call should be gpt-image-1
     first_call = client.images.generate.call_args_list[0]
-    assert first_call.kwargs["model"] == "dall-e-3"
+    assert first_call.kwargs["model"] == "gpt-image-1"
 
     # Second call should be DALL-E 2
     second_call = client.images.generate.call_args_list[1]

--- a/tests/integration/openai/test_openai_api_http.py
+++ b/tests/integration/openai/test_openai_api_http.py
@@ -41,7 +41,7 @@ async def test_generate_image_fallback() -> None:
             return httpx.Response(200, json={})
         model = json.loads(request.content)["model"]
         calls.append(model)
-        if model == "dall-e-3":
+        if model == "gpt-image-1":
             return httpx.Response(500)
         b64 = base64.b64encode(b"img").decode()
         return httpx.Response(200, json={"data": [{"b64_json": b64}]})
@@ -56,7 +56,7 @@ async def test_generate_image_fallback() -> None:
     repo = OpenAIAPIRepository(client)
     result = await repo.generate_image("prompt")
     assert result == b"img"
-    assert calls[0] == "dall-e-3"
+    assert calls[0] == "gpt-image-1"
     assert calls[-1] == "dall-e-2"
 
 


### PR DESCRIPTION
## Summary
- switch image generation to gpt-image-1 with DALL-E 2 fallback
- refine prompt instructions following OpenAI guidelines
- update docs and tests to reflect gpt-image-1 model

## Testing
- `ruff format --check src/ tests/`
- `ruff check src/ tests/`
- `scripts/check-test-names.py`
- `mypy src/`
- `pytest tests/`
- `./scripts/check-quality.sh`


------
https://chatgpt.com/codex/tasks/task_b_6895e4a60428832bbe7cc03fbcd4ce96