### PR TITLE
Migrate prompt enhancer to GPT-5 Responses API; switch fallback to DALL·E 3; fix gpt-image-1 param

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ graph TB
     subgraph "User Interaction"
         A[Slack Message] -->|Right-click| B[Create Reaction Modal]
     end
-    
+
     subgraph "AWS Infrastructure"
         B -->|Submit| C[Webhook Lambda<br/>FastAPI]
         C -->|Queue| D[SQS]
         D -->|Process| E[Worker Lambda]
     end
-    
+
     subgraph "AI Generation"
         E -->|Generate| F[OpenAI gpt-image-1]
         F -->|Upload & React| A
@@ -38,7 +38,7 @@ For detailed architecture documentation, see [Dual Lambda Architecture](./docs/a
 
 **Tech Stack:**
 - **Backend**: Python 3.12 + FastAPI + Slack Bolt
-- **AI Services**: OpenAI o3 with fallback to gpt-4/gpt-3.5 (prompt enhancement) + gpt-image-1 (image generation)
+- **AI Services**: OpenAI GPT-5 with fallback to gpt-4/gpt-3.5 (prompt enhancement) + gpt-image-1 (image generation, with fallback to DALL·E 3)
 - **Infrastructure**: AWS Lambda + API Gateway + SQS + Secrets Manager
 - **Deployment**: AWS CDK + GitHub Actions
 - **Monitoring**: CloudWatch logs + health check endpoint (`/health`)
@@ -136,7 +136,7 @@ aws secretsmanager create-secret --name "emoji-smith/production" --secret-string
 | `SLACK_BOT_TOKEN` | Slack bot user OAuth token | Required | `xoxb-...` |
 | `SLACK_SIGNING_SECRET` | Slack app signing secret | Required | `...` |
 | `OPENAI_API_KEY` | OpenAI API key for gpt-image-1 | Required | `sk-...` |
-| `OPENAI_CHAT_MODEL` | Chat model for prompt enhancement | `o3` | `o3`, `gpt-4`, `gpt-3.5-turbo` |
+| `OPENAI_CHAT_MODEL` | Chat model for prompt enhancement | `gpt-5` | `gpt-5`, `gpt-4`, `gpt-3.5-turbo` |
 | `EMOJISMITH_FORCE_ENTERPRISE` | Force Enterprise Grid mode | `false` | `true`, `false` |
 | `SQS_QUEUE_URL` | AWS SQS queue URL (production) | None | AWS SQS URL |
 | `AWS_SECRETS_NAME` | AWS Secrets Manager name | None | `emoji-smith/production` |

--- a/SETUP.md
+++ b/SETUP.md
@@ -96,7 +96,7 @@ SLACK_SIGNING_SECRET=your-signing-secret-here
 
 # OpenAI API Configuration
 OPENAI_API_KEY=your-openai-api-key         # Required for emoji generation
-OPENAI_CHAT_MODEL=o3                       # Preferred chat model (optional)
+OPENAI_CHAT_MODEL=gpt-5                    # Preferred chat model (optional)
 
 # SQS Background Job Queue (Lambda only)
 SQS_QUEUE_URL=https://sqs.<region>.amazonaws.com/<account-id>/<queue-name>

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -148,7 +148,7 @@ pre-commit run mypy --all-files -v
 
 3. **Optimize prompt generation**
    - Reduce prompt complexity
-   - If gpt-image-1 is rate limited, use DALL-E 2 as a fallback (smaller size)
+  - If gpt-image-1 is rate limited, we fall back to DALL·E 3
 
 ---
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -56,7 +56,7 @@ aws secretsmanager update-secret \
     "SLACK_BOT_TOKEN": "xoxb-your-bot-token",
     "SLACK_SIGNING_SECRET": "your-signing-secret",
     "OPENAI_API_KEY": "sk-your-openai-key",
-    "OPENAI_CHAT_MODEL": "o3",
+    "OPENAI_CHAT_MODEL": "gpt-5",
     "LOG_LEVEL": "INFO"
   }'
 ```

--- a/src/emojismith/app.py
+++ b/src/emojismith/app.py
@@ -48,7 +48,7 @@ def create_worker_emoji_service() -> EmojiCreationService:
     slack_repo = SlackAPIRepository(slack_client)
 
     openai_client = AsyncOpenAI(api_key=openai_api_key)
-    chat_model = os.getenv("OPENAI_CHAT_MODEL", "o3")
+    chat_model = os.getenv("OPENAI_CHAT_MODEL", "gpt-5")
     openai_repo = OpenAIAPIRepository(openai_client, model=chat_model)
 
     image_processor = PillowImageProcessor()


### PR DESCRIPTION
Summary
- Switch prompt enhancement from Chat Completions to Responses API and default model to GPT-5
- Update image generation fallback from DALL·E 2 to DALL·E 3
- Remove unsupported response_format for gpt-image-1
- Update docs and tests accordingly

Details
- src/emojismith/infrastructure/openai/openai_api.py
  - Default chat model to gpt-5
  - Use client.responses.create(...) and return response.output_text
  - Keep image generation via gpt-image-1; fallback to dall-e-3 at 1024x1024 with b64_json
  - Improve system prompt clarity (concise final output guidance)
- tests/integration/openai/
  - Update unit/integration tests to mock Responses API and verify output_text
  - HTTP transport test expects /v1/responses and appropriate payload
- Docs
  - README.md: GPT-5 default, fallback details
  - SETUP.md: OPENAI_CHAT_MODEL=gpt-5
  - infra/README.md & TROUBLESHOOTING.md: updated references to DALL·E 3

QA
- Ran full quality checks: formatting, linting, mypy, tests (341 passed, 3 skipped)

Notes
- Fallback chain for chat remains (gpt-5 -> gpt-4 -> gpt-3.5-turbo)
- Consider adding temperature=0.2 and max_output_tokens to responses.create for determinism
