### PR TITLE
Fix: use supported quality value for gpt-image-1 (high)

### DIFF
--- a/src/emojismith/infrastructure/openai/openai_api.py
+++ b/src/emojismith/infrastructure/openai/openai_api.py
@@ -129,7 +129,7 @@ class OpenAIAPIRepository(OpenAIRepository):
                 prompt=prompt,
                 n=1,
                 size="1024x1024",
-                quality="standard",
+                quality="high",
             )
         except (
             openai.RateLimitError


### PR DESCRIPTION
This PR fixes a production error when gpt-image-1 failed and the fallback to DALL·E 3 was used. The initial gpt-image-1 call passed an unsupported quality value.

Changes
- src/emojismith/infrastructure/openai/openai_api.py
  - gpt-image-1 image generation: change quality from "standard" (invalid) to "high" (supported)

Rationale
- CloudWatch showed 400 errors: Invalid value: 'standard'. Supported values are: 'low', 'medium', 'high', and 'auto'.
- Aligns with current OpenAI Images API for gpt-image-1

Testing
- Ran full test suite: 341 passed, 3 skipped
- Linting/formatting/mypy all clean

No other behavior changes.