### PR TITLE
fix(deploy): use gcloud run deploy instead of terraform

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -126,8 +126,10 @@ jobs:
           echo "worker_image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/emoji-smith/worker:${{ github.sha }}" >> $GITHUB_OUTPUT
 
   # ==========================================================================
-  # Deploy Infrastructure via Terraform (only on main branch)
+  # Deploy Cloud Run Services (only on main branch)
   # ==========================================================================
+  # NOTE: Using gcloud deploy instead of Terraform until existing resources
+  # are imported into Terraform state. See: terraform/README.md for state import.
   deploy:
     needs: build-images
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -148,32 +150,24 @@ jobs:
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.CICD_SERVICE_ACCOUNT }}
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.6.0"
-
-      - name: Terraform Init
-        working-directory: terraform
-        run: |
-          terraform init \
-            -backend-config="bucket=${{ env.PROJECT_ID }}-terraform-state" \
-            -backend-config="prefix=emoji-smith"
-
-      - name: Terraform Apply
-        working-directory: terraform
-        run: |
-          terraform apply -auto-approve \
-            -var="project_id=${{ env.PROJECT_ID }}" \
-            -var="region=${{ env.REGION }}" \
-            -var="github_repo_owner=${{ github.repository_owner }}" \
-            -var="github_repo_name=emoji-smith" \
-            -var="github_repo_owner_id=${{ vars.GH_REPO_OWNER_ID }}" \
-            -var="webhook_image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/emoji-smith/webhook:${{ github.sha }}" \
-            -var="worker_image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/emoji-smith/worker:${{ github.sha }}"
-
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy webhook service
+        run: |
+          gcloud run deploy ${{ env.WEBHOOK_SERVICE }} \
+            --image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/emoji-smith/webhook:${{ github.sha }} \
+            --region=${{ env.REGION }} \
+            --project=${{ env.PROJECT_ID }} \
+            --set-env-vars="ENVIRONMENT=production,TRACING_ENABLED=true,METRICS_ENABLED=true,TRACE_SAMPLE_RATE=1.0"
+
+      - name: Deploy worker service
+        run: |
+          gcloud run deploy ${{ env.WORKER_SERVICE }} \
+            --image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/emoji-smith/worker:${{ github.sha }} \
+            --region=${{ env.REGION }} \
+            --project=${{ env.PROJECT_ID }} \
+            --set-env-vars="ENVIRONMENT=production,TRACING_ENABLED=true,METRICS_ENABLED=true,TRACE_SAMPLE_RATE=1.0"
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
## Summary
- Replace Terraform apply with direct `gcloud run deploy` commands
- Fix deploy failures caused by 409 Conflict (resources already exist but not in Terraform state)
- Ensure observability env vars are deployed (`TRACING_ENABLED`, `METRICS_ENABLED`, `TRACE_SAMPLE_RATE`)

## Background
The previous PR (#406) switched to Terraform for deployments, but Terraform fails because the GCP resources were created manually before and aren't in Terraform state. Import is complex due to dependencies.

This PR reverts to gcloud-based deployment with the observability environment variables, which was the original goal.

## Test plan
- [ ] CI build passes
- [ ] Deploy job succeeds
- [ ] Verify webhook and worker services are updated with new env vars
- [ ] Traces should now appear in GCP Trace Explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)