### PR TITLE
fix(telemetry): add GOOGLE_CLOUD_PROJECT env var to enable Cloud Trace

### DIFF
--- a/terraform/cloud_run_webhook.tf
+++ b/terraform/cloud_run_webhook.tf
@@ -98,6 +98,12 @@ resource "google_cloud_run_v2_service" "webhook" {
         value = "1.0"
       }
 
+      # Required for OpenTelemetry Cloud Trace/Monitoring exporters
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = var.project_id
+      }
+
       # Startup probe for faster scaling
       startup_probe {
         http_get {

--- a/terraform/cloud_run_worker.tf
+++ b/terraform/cloud_run_worker.tf
@@ -100,6 +100,12 @@ resource "google_cloud_run_v2_service" "worker" {
         value = "1.0"
       }
 
+      # Required for OpenTelemetry Cloud Trace/Monitoring exporters
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = var.project_id
+      }
+
       # Health check
       startup_probe {
         http_get {


### PR DESCRIPTION
## Summary

- Adds `GOOGLE_CLOUD_PROJECT` environment variable to both webhook and worker Cloud Run services
- Adds GCP resource detector to properly identify Cloud Run instances for metrics/tracing

## Problems Fixed

### 1. Missing Traces in GCP Trace Explorer
Traces were not appearing despite `TRACING_ENABLED=true`. The telemetry configuration reads `GOOGLE_CLOUD_PROJECT` to configure exporters, and without this variable, `_build_cloud_trace_exporter()` returns `None`.

### 2. Cloud Monitoring "Points must be written in order" Errors
The metrics exporter was using `generic_node` resource type with empty identifiers, causing timestamp conflicts when Cloud Run scales (multiple instances writing with the same empty resource labels).

## Changes

**Terraform:**
- `terraform/cloud_run_webhook.tf`: Added `GOOGLE_CLOUD_PROJECT` env var
- `terraform/cloud_run_worker.tf`: Added `GOOGLE_CLOUD_PROJECT` env var

**Telemetry:**
- `src/shared/infrastructure/telemetry/metrics.py`: Use `GoogleCloudResourceDetector`
- `src/shared/infrastructure/telemetry/tracing.py`: Use `GoogleCloudResourceDetector`

The GCP resource detector populates proper `cloud_run_revision` resource type and labels (project_id, region, service_name, revision_name, instance_id), giving each instance a unique identity.

## Test plan

- [ ] Merge PR to trigger CI/CD
- [ ] Terraform apply will update Cloud Run services
- [ ] Docker images will be rebuilt with the resource detector fix
- [ ] Test Slack emoji generation
- [ ] Verify traces appear in GCP Trace Explorer
- [ ] Verify no "Points must be written in order" errors in logs