### PR TITLE
[codex] update image model defaults

### DIFF
--- a/src/emojismith/application/use_cases/build_prompt_use_case.py
+++ b/src/emojismith/application/use_cases/build_prompt_use_case.py
@@ -54,7 +54,7 @@ class BuildPromptUseCase:
             style_override: Optional style to override the specification's style
 
         Returns:
-            An optimized prompt string ready for gpt-image-1
+            An optimized prompt string ready for the configured image model
         """
         # If style override is provided, create a new spec with that style
         if style_override:

--- a/src/emojismith/domain/services/prompt_builder_service.py
+++ b/src/emojismith/domain/services/prompt_builder_service.py
@@ -47,7 +47,7 @@ class PromptBuilderService:
             spec: The emoji specification containing description, context, and style
 
         Returns:
-            An optimized prompt string ready for gpt-image-1
+            An optimized prompt string ready for the configured image model
         """
         if not spec or not spec.description:
             raise ValueError("Specification must have a description")
@@ -193,7 +193,9 @@ class PromptBuilderService:
         Returns:
             The prompt with emoji requirements added
         """
-        requirements = "as a simple emoji icon"
+        requirements = (
+            "as a simple centered emoji icon with bold silhouette and no text"
+        )
         return f"{prompt} {requirements}"
 
     def optimize_prompt_length(self, prompt: str) -> str:

--- a/src/emojismith/infrastructure/google/gemini_api.py
+++ b/src/emojismith/infrastructure/google/gemini_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any
 
 from google import genai
 from google.api_core import exceptions as google_exceptions
@@ -42,6 +43,10 @@ class GeminiAPIRepository(ImageGenerationRepository, PromptEnhancerRepository):
         self._text_model = text_model
         self._metrics = metrics_recorder
 
+    def _image_size_for_quality(self, quality: str) -> str:
+        """Map shared quality preferences to Google image output sizes."""
+        return "1K" if quality in {"low", "medium"} else "2K"
+
     def _is_rate_limit_error(self, exc: Exception) -> bool:
         """Check if an exception represents a rate limit error.
 
@@ -58,7 +63,9 @@ class GeminiAPIRepository(ImageGenerationRepository, PromptEnhancerRepository):
         # Fallback: check for 429 status code in the error
         return getattr(exc, "code", None) == 429
 
-    async def _generate_with_model(self, prompt: str, model: str) -> bytes:
+    async def _generate_with_model(
+        self, prompt: str, model: str, image_size: str
+    ) -> bytes:
         """Generate image with specified model using native async."""
         response = await self._client.aio.models.generate_content(
             model=model,
@@ -67,16 +74,29 @@ class GeminiAPIRepository(ImageGenerationRepository, PromptEnhancerRepository):
                 response_modalities=["IMAGE"],
                 image_config=types.ImageConfig(
                     aspect_ratio="1:1",
+                    image_size=image_size,
                 ),
             ),
         )
 
-        if response.parts is not None:
-            for part in response.parts:
-                if part.inline_data and part.inline_data.data is not None:
-                    return bytes(part.inline_data.data)
+        for part in self._iter_response_parts(response):
+            if part.inline_data and part.inline_data.data is not None:
+                return bytes(part.inline_data.data)
 
         raise ValueError("Gemini did not return image data")
+
+    def _iter_response_parts(self, response: Any) -> list[Any]:
+        """Return parts from both current and candidate-based SDK responses."""
+        parts = getattr(response, "parts", None)
+        if parts is not None:
+            return list(parts)
+
+        candidates = getattr(response, "candidates", None) or []
+        candidate_parts: list[object] = []
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            candidate_parts.extend(getattr(content, "parts", None) or [])
+        return candidate_parts
 
     async def enhance_prompt(self, context: str, description: str) -> str:
         """Enhance a prompt using Gemini 3 Flash for emoji generation.
@@ -93,16 +113,18 @@ class GeminiAPIRepository(ImageGenerationRepository, PromptEnhancerRepository):
         # 3. Include examples
         # 4. Specify output format
         system_instruction = """You are an expert prompt engineer specializing in \
-creating prompts for AI image generation of Slack emojis.
+creating prompts for Gemini image models and Imagen to generate Slack emojis.
 
 TASK: Transform the user's context and description into an optimized image \
-generation prompt for creating a Slack emoji.
+generation prompt for creating one custom Slack emoji.
 
 REQUIREMENTS:
-- Output must specify a transparent background
-- Optimize for 128x128 pixel display (Slack emoji size)
-- Use bold shapes and high contrast for small-size readability
-- Keep designs simple - avoid fine details that disappear at small sizes
+- Describe a single centered subject or visual metaphor
+- Ask for a transparent background or clean alpha-style cutout when possible
+- Optimize for 128x128 pixel display and readability at 20-32px
+- Use bold shapes, simple composition, and high contrast colors
+- Avoid text, captions, letters, or UI unless explicitly requested
+- Avoid fine details, busy scenes, tiny props, and cropped subjects
 
 OUTPUT FORMAT:
 Return ONLY the optimized prompt text. No explanations, no quotes, no formatting.
@@ -118,20 +140,20 @@ EXAMPLES:
 Input Context: "Just deployed the new feature!"
 Input Description: "rocket ship"
 Output: Cartoon rocket ship with bright orange flames launching upward, \
-bold black outlines, vibrant blue body with red fins, transparent background, \
-optimized for 128x128 pixel Slack emoji
+centered icon composition, bold black outlines, vibrant blue body with red fins, \
+transparent background if supported, optimized for 128x128 Slack emoji
 
 Input Context: "Team standup meeting"
 Input Description: "coffee cup"
 Output: Steaming coffee mug in minimalist flat design, warm brown with \
-white steam curls, simple clean lines, transparent background, \
-optimized for 128x128 pixel Slack emoji
+white steam curls, simple clean lines, centered icon composition, \
+clean removable background, optimized for 128x128 Slack emoji
 
 Input Context: "Bug fixed!"
 Input Description: "celebration"
 Output: Colorful party popper with confetti burst, cartoon style with \
-bold outlines, bright rainbow confetti pieces, transparent background, \
-optimized for 128x128 pixel Slack emoji"""
+bold outlines, a few bright rainbow confetti pieces, centered icon composition, \
+no text, optimized for 128x128 Slack emoji"""
 
         user_message = f"""Input Context: {context}
 Input Description: {description}
@@ -158,7 +180,7 @@ Output:"""
                 raise RateLimitExceededError(str(exc)) from exc
             raise
 
-    async def _generate_with_imagen(self, prompt: str) -> bytes:
+    async def _generate_with_imagen(self, prompt: str, image_size: str) -> bytes:
         """Generate image with Imagen 4 Ultra fallback.
 
         Uses the Imagen API which has a different method signature than Gemini.
@@ -169,6 +191,7 @@ Output:"""
             config=types.GenerateImagesConfig(
                 number_of_images=1,
                 aspect_ratio="1:1",
+                image_size=image_size,
             ),
         )
 
@@ -201,14 +224,17 @@ Output:"""
             List of image bytes
         """
         # Unused parameters kept for protocol compatibility
-        _ = quality, background
+        _ = background
         images = []
         n = min(num_images, 4)
+        image_size = self._image_size_for_quality(quality)
 
         for _ in range(n):
             try:
                 start_time = time.monotonic()
-                image_bytes = await self._generate_with_model(prompt, self._model)
+                image_bytes = await self._generate_with_model(
+                    prompt, self._model, image_size
+                )
                 duration_s = time.monotonic() - start_time
                 log_event(
                     self._logger,
@@ -239,7 +265,7 @@ Output:"""
                 )
                 try:
                     start_time = time.monotonic()
-                    image_bytes = await self._generate_with_imagen(prompt)
+                    image_bytes = await self._generate_with_imagen(prompt, image_size)
                     duration_s = time.monotonic() - start_time
                     log_event(
                         self._logger,

--- a/src/emojismith/infrastructure/openai/openai_api.py
+++ b/src/emojismith/infrastructure/openai/openai_api.py
@@ -20,6 +20,9 @@ from emojismith.domain.repositories.openai_repository import OpenAIRepository
 from shared.infrastructure.logging import log_event
 from shared.infrastructure.telemetry.metrics import MetricsRecorder
 
+OPENAI_IMAGE_MODEL = "gpt-image-2"
+OPENAI_IMAGE_FALLBACK_MODELS = ["gpt-image-1.5", "gpt-image-1-mini"]
+
 
 class OpenAIAPIRepository(OpenAIRepository, ImageGenerationRepository):
     """Concrete OpenAI repository using openai package."""
@@ -66,25 +69,33 @@ class OpenAIAPIRepository(OpenAIRepository, ImageGenerationRepository):
         await self._ensure_model()
 
         system_prompt = (
-            "You are an expert at crafting prompts for OpenAI's gpt-image-1 model "
-            "to create Slack emojis. Use the guidelines below.\n\n"
+            "You are an expert at crafting prompts for OpenAI GPT Image models, "
+            "including gpt-image-2, to create custom Slack emojis. "
+            "Use the guidelines below.\n\n"
             "REQUIREMENTS:\n"
-            "- Always mention a transparent background.\n"
-            "- Optimize for 128x128 pixel Slack emoji display.\n"
-            "- Keep shapes bold and high contrast for readability at tiny sizes.\n\n"
+            "- Describe a single centered emoji subject with a clean silhouette.\n"
+            "- Optimize for 128x128 pixel Slack emoji display and readability "
+            "at 20-32px.\n"
+            "- Use bold shapes, simple composition, and high contrast colors.\n"
+            "- Ask for a transparent background when supported; otherwise ask for an "
+            "isolated subject on a plain, removable background.\n"
+            "- Do not include text, letters, captions, or UI unless the user "
+            "explicitly requests text.\n\n"
             "FORMAT:\n"
-            '"[Style] [Subject] with [Key Features], transparent background, '
-            'optimized for 128x128 pixel Slack emoji, [Additional Details]"\n\n'
+            '"[Style/medium] [single subject/action] with [2-3 distinctive visual '
+            "features], centered icon composition, bold silhouette, optimized for "
+            '128x128 Slack emoji, [background guidance]"\n\n'
             "STYLE OPTIONS:\n"
             "- Cartoon style for playful emojis\n"
             "- Minimalist flat design for professional contexts\n"
             "- Pixel art for retro themes\n"
             "- Realistic style for objects/foods\n\n"
             "PROMPT RULES:\n"
-            "1. Simplify complex descriptions.\n"
+            "1. Turn vague or complex requests into one clear visual metaphor.\n"
             "2. Highlight distinctive features visible when small.\n"
-            "3. Use vibrant contrasting colors.\n"
-            "4. Avoid intricate detail.\n"
+            "3. Use concrete nouns, colors, materials, and emotion cues.\n"
+            "4. Avoid busy backgrounds, tiny props, cropped subjects, and "
+            "fine detail.\n"
             "5. Incorporate message context when useful.\n"
             "6. Return only the final prompt text, "
             "without quotes or extra formatting.\n"
@@ -93,16 +104,17 @@ class OpenAIAPIRepository(OpenAIRepository, ImageGenerationRepository):
             "EXAMPLES:\n"
             'Context: "Just shipped new feature" / Description: "rocket"\n'
             'Prompt: "Cartoon rocket launching with bright orange flames, '
-            "transparent background, optimized for 128x128 pixel Slack emoji, "
-            'bold outlines, vibrant colors"\n\n'
+            "centered icon composition, bold silhouette, vibrant blue body and red "
+            "fins, optimized for 128x128 Slack emoji, transparent background "
+            'if supported"\n\n'
             'Context: "Team celebration" / Description: "party"\n'
-            'Prompt: "Festive party popper bursting with confetti, transparent '
-            "background, optimized for 128x128 pixel Slack emoji, cartoon style, "
-            'bold colors"\n\n'
+            'Prompt: "Festive party popper bursting with a few large confetti pieces, '
+            "simple cartoon style, centered icon composition, bold outlines, bright "
+            'colors, optimized for 128x128 Slack emoji, isolated plain background"\n\n'
             'Context: "Coffee break" / Description: "tired"\n'
             'Prompt: "Sleepy face clutching coffee cup with rising steam, '
-            "transparent background, optimized for 128x128 pixel Slack emoji, "
-            'simple cartoon style, clear expression"\n'
+            "simple cartoon style, clear tired expression, bold silhouette, "
+            'optimized for 128x128 Slack emoji, no text"\n'
         )
 
         try:
@@ -149,40 +161,41 @@ class OpenAIAPIRepository(OpenAIRepository, ImageGenerationRepository):
         # Cap at 4 images for reasonable UX
         start_time = time.monotonic()
         n = min(num_images, 4)
-        used_model = "gpt-image-1.5"
+        models_to_try = [OPENAI_IMAGE_MODEL, *OPENAI_IMAGE_FALLBACK_MODELS]
+        used_model = OPENAI_IMAGE_MODEL
         is_fallback = False
 
-        try:
-            response = await self._client.images.generate(
-                model=used_model,
-                prompt=prompt,
-                n=n,
-                size="1024x1024",
-                quality=quality,
-                background=background,
-                # GPT image models use output_format, not response_format
-                output_format="png",
-            )
-        except openai.RateLimitError as exc:
-            raise RateLimitExceededError(str(exc)) from exc
-        except Exception as exc:
-            self._logger.warning(
-                "gpt-image-1.5 failed, falling back to gpt-image-1-mini: %s", exc
-            )
+        for index, candidate_model in enumerate(models_to_try):
+            used_model = candidate_model
+            is_fallback = index > 0
+            request_background = background
+            if candidate_model == OPENAI_IMAGE_MODEL and background == "transparent":
+                # gpt-image-2 currently rejects transparent background requests.
+                request_background = "auto"
+
             try:
-                used_model = "gpt-image-1-mini"
-                is_fallback = True
                 response = await self._client.images.generate(
                     model=used_model,
                     prompt=prompt,
                     n=n,
                     size="1024x1024",
-                    background=background,
-                    # GPT image models use output_format
+                    quality=quality,
+                    background=request_background,
                     output_format="png",
                 )
+                break
             except openai.RateLimitError as rate_exc:
                 raise RateLimitExceededError(str(rate_exc)) from rate_exc
+            except Exception as exc:
+                if index == len(models_to_try) - 1:
+                    raise
+                next_model = models_to_try[index + 1]
+                self._logger.warning(
+                    "%s failed, falling back to %s: %s",
+                    used_model,
+                    next_model,
+                    exc,
+                )
 
         if not response.data:
             raise ValueError("OpenAI did not return image data")

--- a/src/shared/domain/value_objects.py
+++ b/src/shared/domain/value_objects.py
@@ -344,11 +344,12 @@ class EmojiGenerationPreferences:
         per Slack requirements.
         """
         base = (
-            ", bold shapes, high contrast, "
+            ", single centered subject, bold shapes, bold silhouette, high contrast, "
+            "no text unless explicitly requested, "
             "optimized for 128x128 Slack emoji display at 20-32px"
         )
         if self.background == BackgroundType.TRANSPARENT:
-            return f", transparent background{base}"
+            return f", transparent background or clean alpha-style cutout{base}"
         return base
 
     @classmethod

--- a/tests/contract/google/test_gemini_api.py
+++ b/tests/contract/google/test_gemini_api.py
@@ -58,6 +58,36 @@ class TestGeminiAPIRepositoryGenerateImage:
         # Assert
         assert result == [expected_image_data]
         mock_gemini_client.aio.models.generate_content.assert_called_once()
+        call = mock_gemini_client.aio.models.generate_content.call_args
+        config = call.kwargs["config"]
+        assert config.image_config.aspect_ratio == "1:1"
+        assert config.image_config.image_size == "2K"
+
+    @pytest.mark.asyncio()
+    async def test_generate_image_reads_candidate_content_parts(
+        self, repository, mock_gemini_client
+    ):
+        """Support candidate-based response shapes from newer SDK responses."""
+        # Arrange
+        expected_image_data = b"candidate_image_bytes"
+        mock_part = MagicMock()
+        mock_part.inline_data = MagicMock()
+        mock_part.inline_data.data = expected_image_data
+
+        mock_candidate = MagicMock()
+        mock_candidate.content.parts = [mock_part]
+
+        mock_response = MagicMock()
+        mock_response.parts = None
+        mock_response.candidates = [mock_candidate]
+
+        mock_gemini_client.aio.models.generate_content.return_value = mock_response
+
+        # Act
+        result = await repository.generate_image("Test prompt")
+
+        # Assert
+        assert result == [expected_image_data]
 
     @pytest.mark.asyncio()
     async def test_generate_image_when_primary_fails_uses_imagen_fallback(
@@ -90,6 +120,10 @@ class TestGeminiAPIRepositoryGenerateImage:
         assert result == [expected_image_data]
         mock_gemini_client.aio.models.generate_content.assert_called_once()
         mock_gemini_client.aio.models.generate_images.assert_called_once()
+        call = mock_gemini_client.aio.models.generate_images.call_args
+        config = call.kwargs["config"]
+        assert config.aspect_ratio == "1:1"
+        assert config.image_size == "2K"
 
     @pytest.mark.asyncio()
     async def test_generate_image_when_quota_exceeded_raises_rate_limit_error(

--- a/tests/integration/openai/test_openai_api.py
+++ b/tests/integration/openai/test_openai_api.py
@@ -117,14 +117,34 @@ async def test_rejects_image_generation_when_b64_json_is_none() -> None:
 
 @pytest.mark.asyncio()
 @pytest.mark.integration()
-async def test_falls_back_to_mini_when_gpt_image_fails() -> None:
-    """Test fallback to gpt-image-1-mini when primary model fails."""
+async def test_generate_image_uses_gpt_image_2_with_supported_background() -> None:
+    """Use the latest high-end OpenAI image model without unsupported transparency."""
+    client = AsyncMock()
+    client.images.generate.return_value = AsyncMock(
+        data=[AsyncMock(b64_json="aGVsbG8=")]
+    )
+    repo = OpenAIAPIRepository(client)
+
+    result = await repo.generate_image("test prompt", background="transparent")
+
+    assert result == [b"hello"]
+    client.images.generate.assert_called_once()
+    call = client.images.generate.call_args
+    assert call.kwargs["model"] == "gpt-image-2"
+    assert call.kwargs["background"] == "auto"
+    assert call.kwargs["output_format"] == "png"
+
+
+@pytest.mark.asyncio()
+@pytest.mark.integration()
+async def test_falls_back_to_gpt_image_1_5_when_gpt_image_2_fails() -> None:
+    """Test fallback to gpt-image-1.5 when primary model fails."""
     client = AsyncMock()
 
-    # First call (gpt-image-1.5) fails
+    # First call (gpt-image-2) fails
     client.images.generate.side_effect = [
-        Exception("gpt-image-1.5 not available"),
-        AsyncMock(data=[AsyncMock(b64_json="aGVsbG8=")]),  # gpt-image-1-mini succeeds
+        Exception("gpt-image-2 not available"),
+        AsyncMock(data=[AsyncMock(b64_json="aGVsbG8=")]),  # gpt-image-1.5 succeeds
     ]
 
     repo = OpenAIAPIRepository(client)
@@ -133,13 +153,14 @@ async def test_falls_back_to_mini_when_gpt_image_fails() -> None:
     # Should have called both models
     assert client.images.generate.call_count == 2
 
-    # First call should be gpt-image-1.5
+    # First call should be gpt-image-2
     first_call = client.images.generate.call_args_list[0]
-    assert first_call.kwargs["model"] == "gpt-image-1.5"
+    assert first_call.kwargs["model"] == "gpt-image-2"
 
-    # Second call should be gpt-image-1-mini
+    # Second call should be gpt-image-1.5, preserving transparent background
     second_call = client.images.generate.call_args_list[1]
-    assert second_call.kwargs["model"] == "gpt-image-1-mini"
+    assert second_call.kwargs["model"] == "gpt-image-1.5"
+    assert second_call.kwargs["background"] == "transparent"
     assert second_call.kwargs["size"] == "1024x1024"
 
     # Should return list of bytes

--- a/tests/integration/openai/test_openai_api_http.py
+++ b/tests/integration/openai/test_openai_api_http.py
@@ -54,7 +54,7 @@ async def test_generate_image_fallback() -> None:
             return httpx.Response(200, json={})
         model = json.loads(request.content)["model"]
         calls.append(model)
-        if model == "gpt-image-1.5":
+        if model == "gpt-image-2":
             return httpx.Response(500)
         b64 = base64.b64encode(b"img").decode()
         return httpx.Response(200, json={"data": [{"b64_json": b64}]})
@@ -69,8 +69,8 @@ async def test_generate_image_fallback() -> None:
     repo = OpenAIAPIRepository(client)
     result = await repo.generate_image("prompt")
     assert result == [b"img"]  # Returns list of bytes
-    assert calls[0] == "gpt-image-1.5"
-    assert calls[-1] == "gpt-image-1-mini"
+    assert calls[0] == "gpt-image-2"
+    assert calls[-1] == "gpt-image-1.5"
 
 
 @pytest.mark.asyncio()

--- a/tests/unit/infrastructure/openai/test_openai_api_logging.py
+++ b/tests/unit/infrastructure/openai/test_openai_api_logging.py
@@ -20,7 +20,7 @@ async def test_generate_image_logs_model_generation_primary(caplog) -> None:
         return_value=SimpleNamespace(data=[SimpleNamespace(b64_json="aGVsbG8=")])
     )
 
-    repository = OpenAIAPIRepository(client, model="gpt-image-1.5")
+    repository = OpenAIAPIRepository(client, model="gpt-5")
 
     with caplog.at_level(logging.INFO):
         await repository.generate_image("test prompt")
@@ -33,7 +33,7 @@ async def test_generate_image_logs_model_generation_primary(caplog) -> None:
 
     assert len(generation_logs) == 1
     assert generation_logs[0].event_data["provider"] == "openai"
-    assert generation_logs[0].event_data["model"] == "gpt-image-1.5"
+    assert generation_logs[0].event_data["model"] == "gpt-image-2"
     assert generation_logs[0].event_data["is_fallback"] is False
 
 
@@ -49,7 +49,7 @@ async def test_generate_image_logs_model_generation_fallback(caplog) -> None:
         ]
     )
 
-    repository = OpenAIAPIRepository(client, model="gpt-image-1.5")
+    repository = OpenAIAPIRepository(client, model="gpt-5")
 
     with caplog.at_level(logging.INFO):
         await repository.generate_image("test prompt")
@@ -62,5 +62,5 @@ async def test_generate_image_logs_model_generation_fallback(caplog) -> None:
 
     assert len(generation_logs) == 1
     assert generation_logs[0].event_data["provider"] == "openai"
-    assert generation_logs[0].event_data["model"] == "gpt-image-1-mini"
+    assert generation_logs[0].event_data["model"] == "gpt-image-1.5"
     assert generation_logs[0].event_data["is_fallback"] is True


### PR DESCRIPTION
## What changed
- Updated OpenAI image generation to try `gpt-image-2` first, then fall back to `gpt-image-1.5` and `gpt-image-1-mini`.
- Adjusted OpenAI prompt enhancement guidance for small Slack emoji assets and the `gpt-image-2` transparent-background limitation.
- Updated Google image generation to request 2K output for high/auto quality with Gemini/Imagen, while keeping 1K for low/medium quality.
- Tightened Google response parsing to handle both top-level `response.parts` and candidate-based SDK response shapes.
- Refined active emoji prompt fragments for centered composition, bold silhouettes, small-size readability, and avoiding text unless requested.

## Why
Provider docs now identify `gpt-image-2` as OpenAI's latest image model. Google keeps Nano Banana Pro (`gemini-3-pro-image-preview`) as its highest-end native image model and Imagen 4 Ultra as the high-end Imagen fallback; the current SDK supports image sizing on those requests.

## Impact
OpenAI jobs use the latest primary image model where supported. Because `gpt-image-2` does not support transparent-background requests, transparent OpenAI requests use `background="auto"` for the primary attempt and preserve `background="transparent"` on fallback models. Google high-quality jobs request 2K source images before the existing Slack resizing pipeline.

## Validation
- `source .venv/bin/activate && pytest tests/integration/openai tests/unit/infrastructure/openai tests/contract/google tests/unit/infrastructure/google tests/unit/domain/services/test_prompt_builder_service.py tests/unit/application/use_cases/test_build_prompt_use_case.py tests/unit/application/services/test_emoji_service.py`
- `source .venv/bin/activate && just qa`