### PR TITLE
[codex] fix Terraform deploy provider signature failure

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.6.0"
+          terraform_version: "1.15.4"
 
       - name: Terraform Init
         working-directory: terraform


### PR DESCRIPTION
## What changed
- Bumped the GCP deploy workflow Terraform CLI from `1.6.0` to `1.15.4`.

## Why
The failed deploy run reached `Terraform Init` successfully, configured the GCS backend, then failed installing `hashicorp/google` and `hashicorp/google-beta` v7.17.0 with `openpgp: key expired`. The workflow was pinned to an old Terraform CLI that cannot validate the currently signed provider packages.

## Validation
- `source .venv/bin/activate && terraform -chdir=terraform init -backend=false`
- `source .venv/bin/activate && git diff --check`

## Deployment plan
After PR checks pass, merge to `main` so the existing push-to-main deploy workflow builds images, runs Terraform, and verifies Cloud Run services.